### PR TITLE
Make schema a const level recommendation & minor improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,9 @@ sidebar_position: 0
 title: "Overview"
 ---
 
-# Core Schema Notation Interoperability Specification v1.0 Beta
+# Core Schema Notation Interoperability Specification
+
+**STATUS**: v1.0 <span className="feature-status-beta">BETA</span>, stable release planned for 2025-02.
 
 ## Summary
 
@@ -38,8 +40,7 @@ A CSN Interop file can look like this (extracted from [./examples/airline.json](
         "AirlineID": {
           "doc": "Human readable description of the element, in **markdown**.",
           "key": true,
-          "type": "cds.UUID"
-} } } } }
+          "type": "cds.UUID" } } } } }
 ```
 
 To get a first overview, read the [informal Primer](./primer.md).
@@ -78,16 +79,15 @@ This includes:
 Right now, this spec describes only the [effective](./spec-v1/csn-interop-effective) feature dimension.
 
 Effective means that the format is "[denormalized](https://en.wikipedia.org/wiki/Denormalization)", and optimized towards easy consumption by machines, with the tradeoff of more verbosity and duplicated information.
-Information reuse concepts like aspects have already been resolved, applied and cleaned up. What the consumer gets, is a document that does not require further post-processing / logic to be interpreted correctly.
+
+Information reuse concepts like aspects have already been resolved, applied and cleaned up. What the consumer gets, is a document that does not require further post-processing / logic to be interpreted correctly. This is a tradeoff, prioritizing easy consumption over convenient creation.
 
 ## Intended Audience
 
 - Developers and Architects that either need to export or import CSN across different technology stacks.
 - End consumers that need to understand CSN Interop as a metadata description format for resources they want to integrate with (e.g. APIs and Events).
 
-## Status and Contributors
-
-**STATUS**: <span className="feature-status-beta">BETA</span>, stable release planned for 2025-02.
+## Contact
 
 **CONTACT**: Create a GitHub PR or [issue](https://github.com/SAP/csn-interop-specification/issues).
 

--- a/docs/primer.md
+++ b/docs/primer.md
@@ -57,6 +57,22 @@ There are three mandatory root level properties that need to be added to get a m
 - `definitions` at least one element of a definition modelling artefact
 - See [Root Interface documentation](./spec-v1/csn-interop-effective#csn-interop-root) for a complete overview.
 
+Optionally, metadata about the document as a whole can be added in [meta](./spec-v1/csn-interop-effective.md#meta).
+It is also recommended to add `$schema` for JSON Schema based validation / code intelligence in IDEs and editors.
+
+```js
+{
+  "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
+  "meta": {
+    "document": {
+      "version": "1.2.3",
+      "doc": "This CSN example document shows how the airline example is expressed with a CDS **Service** exposing the entities through an API."
+    }
+  },
+  // ...
+}
+```
+
 ## Definitions
 
 The model is described in the [Definitions](./spec-v1/csn-interop-effective#definitions) section.

--- a/examples/airline.json
+++ b/examples/airline.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
   "csnInteropEffective": "1.0",
   "$version": "2.0",
   "meta": {

--- a/examples/airline.md
+++ b/examples/airline.md
@@ -3,7 +3,7 @@ title: Airline
 sidebar_position: 1
 ---
 
-## Airline
+## Description
 
 The airline example is our primary example file:
 

--- a/examples/entities_with_annotations.json
+++ b/examples/entities_with_annotations.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
   "csnInteropEffective": "1.0",
   "$version": "2.0",
   "meta": {

--- a/examples/entities_with_annotations.md
+++ b/examples/entities_with_annotations.md
@@ -1,0 +1,8 @@
+---
+title: Entities with Annotations
+sidebar_position: 1
+---
+
+## Description
+
+This example showcases the use of [Annotations](../../annotations/).

--- a/examples/entities_with_foreign_key_and_text_assocs.json
+++ b/examples/entities_with_foreign_key_and_text_assocs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
   "csnInteropEffective": "1.0",
   "$version": "2.0",
   "meta": {

--- a/examples/entities_with_foreign_key_and_text_assocs.md
+++ b/examples/entities_with_foreign_key_and_text_assocs.md
@@ -1,0 +1,8 @@
+---
+title: Entities with Associations
+sidebar_position: 1
+---
+
+## Description
+
+This example focuses on the use of `cds.Association` and the `@ObjectModel.foreignKey.association` annotation.

--- a/examples/tables_with_primary_key.json
+++ b/examples/tables_with_primary_key.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
   "csnInteropEffective": "1.0",
   "$version": "2.0",
   "meta": {

--- a/examples/tables_with_primary_key.md
+++ b/examples/tables_with_primary_key.md
@@ -1,0 +1,8 @@
+---
+title: Tables with Primary Key
+sidebar_position: 1
+---
+
+## Description
+
+This example shows how a CSN model can describe a data model for relational database tables with primary keys.

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -72,19 +72,17 @@ definitions:
           Adding this helps with automatic validation and code intelligence in some editors / IDEs.
 
           See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
-
-        examples:
-          - https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json
+        anyOf:
+          - const: https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json
+          - type: string
+            format: uri-reference
       $id:
         type: string
         format: uri-reference
         description: |
-          Optional URI for this document, that can acts as an ID.
+          Optional URI for this document, that can acts as an ID or as location to retrieve the document.
 
           See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
-        examples:
-          - https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.ext.schema.json
-          - https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json
       csnInteropEffective:
         type: string
         description: |-

--- a/src/spec-toolkit/generateExampleDocumentation.ts
+++ b/src/spec-toolkit/generateExampleDocumentation.ts
@@ -51,7 +51,7 @@ function generateExampleDocumentationPage(filePaths: string[], documentType: str
     }
 
     log.info(`Found ${documentType} example file: ${filePath}`);
-    text += `### ${filePath}\n\n`;
+    text += `## Example File\n\n`;
     text += `> Source Code: [${filePath}](${filePath.replace(
       "./",
       "https://github.com/SAP/csn-interop-specification/blob/main/",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -8585,8 +8585,14 @@
       "type": "string",
       "format": "uri-reference",
       "description": "Link to JSON Schema for this CSN Interop Effective document.\nAdding this helps with automatic validation and code intelligence in some editors / IDEs.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
-      "examples": [
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+      "anyOf": [
+        {
+          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+        },
+        {
+          "type": "string",
+          "format": "uri-reference"
+        }
       ],
       "x-context": [
         "./spec/v1/CSN-Interop-Effective.schema.yaml",
@@ -8597,11 +8603,7 @@
     "$id": {
       "type": "string",
       "format": "uri-reference",
-      "description": "Optional URI for this document, that can acts as an ID.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
-      "examples": [
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.ext.schema.json",
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
-      ],
+      "description": "Optional URI for this document, that can acts as an ID or as location to retrieve the document.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
       "x-context": [
         "./spec/v1/CSN-Interop-Effective.schema.yaml",
         "CsnInteropEffectiveRoot",

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -6666,18 +6666,20 @@
       "type": "string",
       "format": "uri-reference",
       "description": "Link to JSON Schema for this CSN Interop Effective document.\nAdding this helps with automatic validation and code intelligence in some editors / IDEs.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
-      "examples": [
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+      "anyOf": [
+        {
+          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+        },
+        {
+          "type": "string",
+          "format": "uri-reference"
+        }
       ]
     },
     "$id": {
       "type": "string",
       "format": "uri-reference",
-      "description": "Optional URI for this document, that can acts as an ID.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
-      "examples": [
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.ext.schema.json",
-        "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
-      ]
+      "description": "Optional URI for this document, that can acts as an ID or as location to retrieve the document.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n"
     },
     "csnInteropEffective": {
       "type": "string",

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -315,9 +315,10 @@ export interface CSNInteropRoot {
    * See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
    *
    */
-  $schema?: string;
+  $schema?: ("https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json" | string) &
+    string;
   /**
-   * Optional URI for this document, that can acts as an ID.
+   * Optional URI for this document, that can acts as an ID or as location to retrieve the document.
    *
    * See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
    *


### PR DESCRIPTION
Promote the use of `$schema` more strongly by making it a "anyOf" enum option. It's still possible to link to any URI, but by default we now recommend 

```js
{
    "$schema": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
}
```

Adding some header / markdown files to examples for consistency and nicer sidebar menu.