### PR TITLE
Feat: Add meta.document.title

### DIFF
--- a/examples/airline.json
+++ b/examples/airline.json
@@ -5,6 +5,7 @@
   "meta": {
     "document": {
       "version": "1.2.3",
+      "title": "Airline Example",
       "doc": "This CSN example document shows how the airline example is expressed with a CDS **Service** exposing the entities through an API."
     },
     "features": {
@@ -239,6 +240,7 @@
           "type": "cds.Association",
           "target": "AirlineService.Airline",
           "cardinality": {
+            "min": 0,
             "max": "*"
           },
           "on": [

--- a/examples/airline.json
+++ b/examples/airline.json
@@ -5,7 +5,7 @@
   "meta": {
     "document": {
       "version": "1.2.3",
-      "title": "Airline Example",
+      "title": "Airline (Example)",
       "doc": "This CSN example document shows how the airline example is expressed with a CDS **Service** exposing the entities through an API."
     },
     "features": {

--- a/examples/entities_with_annotations.json
+++ b/examples/entities_with_annotations.json
@@ -4,7 +4,8 @@
   "$version": "2.0",
   "meta": {
     "document": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "title": "Entities with Annotations (Example)"
     },
     "features": {
       "complete": true

--- a/examples/entities_with_foreign_key_and_text_assocs.json
+++ b/examples/entities_with_foreign_key_and_text_assocs.json
@@ -4,7 +4,8 @@
   "$version": "2.0",
   "meta": {
     "document": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "title": "Entities with Foreign Key and Text Associations (Example)"
     },
     "features": {
       "complete": true

--- a/examples/tables_with_primary_key.json
+++ b/examples/tables_with_primary_key.json
@@ -4,7 +4,8 @@
   "$version": "2.0",
   "meta": {
     "document": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "title": "Tables with Primary Keys (Example)"
     },
     "features": {
       "complete": true

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -192,7 +192,7 @@ definitions:
         description: |-
           Human readable documentation that describes the overall CSN document.
 
-          SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+          SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
     additionalProperties: false
 
   MetaFeatures:
@@ -368,10 +368,11 @@ definitions:
       doc: &doc
         type: string
         description: |-
-          Human readable documentation.
+          Human readable documentation, usually for developer documentation.
 
-          SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+          SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
 
+          If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
       #-------------------------------------------------------------
       #--Hidden Properties (added to ignore them in the validation)
       #-------------------------------------------------------------

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -182,6 +182,11 @@ definitions:
           We RECOMMEND to use the [SemVer](https://semver.org/) standard.
         examples:
           - "1.3.4"
+      title:
+        type: string
+        maxLength: 255
+        description: |-
+          Human readable title for the CSN document (plain-text).
       doc:
         type: string
         description: |-

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -1335,8 +1335,6 @@ definitions:
   DefaultValueObject:
     title: Default Value object
     type: object
-    description: |-
-      Indicates the default value.
     properties:
       val:
         type: ["object", "null"]

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -262,11 +262,11 @@ definitions:
       The `name` is the absolute, fully qualified name of the definition, and the value is a record with the definition details.
 
       Definition names MUST:
-      * Not be an empty string.
-      * Not start with `@`, `__`, `.`, `::`.
-      * Not end with `.` or `::`.
-      * Not contain the substring `..` or `:::`.
-      * Not contain the substring `::` more than once.
+      - Not be an empty string.
+      - Not start with `@`, `__`, `.`, `::`.
+      - Not end with `.` or `::`.
+      - Not contain the substring `..` or `:::`.
+      - Not contain the substring `::` more than once.
 
       See [Primer: Definitions](../primer.md#definitions).
 
@@ -449,9 +449,9 @@ definitions:
           Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
 
           Correct annotations examples:
-          * `"@Common.bar": "foo"`
-          * `"@Common.foo.bar": true`
-          * `"@Common.array": [{ "foo": true }]`
+          - `"@Common.bar": "foo"`
+          - `"@Common.foo.bar": true`
+          - `"@Common.array": [{ "foo": true }]`
 
           Or
 
@@ -473,11 +473,11 @@ definitions:
       The value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).
 
       Element names MUST:
-      * Not be an empty string.
-      * Not start with `@`, `__`, `::`.
-      * Not end with `::`.
-      * Not contain the substring `.` or `:::`.
-      * Not contain the substring `::` more than once.
+      - Not be an empty string.
+      - Not start with `@`, `__`, `::`.
+      - Not end with `::`.
+      - Not contain the substring `.` or `:::`.
+      - Not contain the substring `::` more than once.
     minProperties: 1
     patternProperties:
       '^(?![@]|__|\.|::).+$':
@@ -1062,7 +1062,7 @@ definitions:
         type: object
         $ref: "#/definitions/CardinalityObject"
 
-      "on":
+      "on": &on
         type: array
         description: |-
           The property `on` holds a sequence of operators and operands to describe the join condition.
@@ -1073,12 +1073,11 @@ definitions:
           - One of the following:
             - Reference to a field of the source entity
             - Constant Value
+
           This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
+          In addition, several building blocks can be lined up using an "and" operator.
 
-          In addition, several building blocks can be lined up using an "and" operator
-
-          More information can be found here:
-          * https://cap.cloud.sap/docs/cds/csn#assoc-on
+          See also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).
 
         items:
           oneOf:
@@ -1156,50 +1155,8 @@ definitions:
         type: object
         $ref: "#/definitions/CardinalityObject"
 
-      on:
-        type: array
-        description: |-
-          The property `on` holds a sequence of operators and operands to describe the join condition.
+      on: *on
 
-          One building block of the sequence consists of the following in the given order:
-          - Reference to a field of the association or composition target
-          - Equals Operator "="
-          - One of the following:
-            - Reference to a field of the source entity
-            - Constant Value
-          This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
-
-          In addition, several building blocks can be lined up using an "and" operator
-
-          More information can be found here:
-          * https://cap.cloud.sap/docs/cds/csn#assoc-on
-
-        items:
-          oneOf:
-            - $ref: "#/definitions/StructuredElementReference"
-            - $ref: "#/definitions/EqualsOperator"
-            - $ref: "#/definitions/AndOperator"
-            - $ref: "#/definitions/OnValue"
-        examples:
-          - [{ "ref": ["to_Connection", "AirlineID"] }, "=", { "ref": ["AirlineID"] }]
-          - [
-              { "ref": ["to_Connection", "AirlineID"] },
-              "=",
-              { "ref": ["AirlineID"] },
-              "and",
-              { "ref": ["to_Connection", "ConnectionID"] },
-              "=",
-              { "ref": ["ConnectionID"] },
-            ]
-          - [
-              { "ref": ["to_Connection", "AirlineID"] },
-              "=",
-              { "ref": ["AirlineID"] },
-              "and",
-              { "ref": ["to_Connection", "ConnectionID"] },
-              "=",
-              { "val": "1234567" },
-            ]
     patternProperties: *patternPropertiesAnnotationsAndPrivate
     required:
       - "type"
@@ -1235,8 +1192,8 @@ definitions:
 
       CSN Interop Effective adds further constraints to make a simple type lookup possible:
 
-      * A Custom Type MUST NOT point to another Custom Type (no recursion).
-      * The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the "effective" quality.
+      - A Custom Type MUST NOT point to another Custom Type (no recursion).
+      - The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the "effective" quality.
 
       This will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.
       All other properties describing the Custom Type can already be found at the Custom Type itself.
@@ -1377,7 +1334,7 @@ definitions:
     oneOf:
       - const: "floating"
         description: |-
-          The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the Precision
+          The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the `precision`.
 
           See https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale
       # Decision: We don't support 'variable' yet, because support / shared understanding seem to be not given.
@@ -1410,8 +1367,8 @@ definitions:
           Specifies the targets maximum cardinality.
 
           MUST be one of:
-          * positive Integer (1,2,...)
-          * `*` as String
+          - positive Integer (1,2,...)
+          - `*` as String
 
         type: ["number", "string"]
         default: 1
@@ -1434,9 +1391,10 @@ definitions:
         description: |-
           Description of the target with *association name* and *target element name* in target entity`
           Description of the source *source element name*
+
           MUST NOT:
-          * use $ as leading character of an element
-          * use session variables
+          - use $ as leading character of an element
+          - use session variables
         items:
           type: string
           x-association-target: &associationTargetAllElements

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -186,6 +186,16 @@
             "version"
           ]
         },
+        "title": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Human readable title for the CSN document (plain-text).",
+          "x-context": [
+            "./spec/v1/CSN-Interop-Effective.schema.yaml",
+            "MetaDocument",
+            "title"
+          ]
+        },
         "doc": {
           "type": "string",
           "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -198,7 +198,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "MetaDocument",
@@ -395,7 +395,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "EntityDefinition",
@@ -1032,7 +1032,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "BooleanType",
@@ -1257,7 +1257,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "StringType",
@@ -1493,7 +1493,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "LargeStringType",
@@ -1738,7 +1738,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "IntegerType",
@@ -1971,7 +1971,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "Integer64Type",
@@ -2195,7 +2195,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DecimalType",
@@ -2449,7 +2449,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DoubleType",
@@ -2682,7 +2682,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DateType",
@@ -2913,7 +2913,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "TimeType",
@@ -3144,7 +3144,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DateTimeType",
@@ -3375,7 +3375,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "TimestampType",
@@ -3606,7 +3606,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "UUIDType",
@@ -3811,7 +3811,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "AssociationType",
@@ -4142,7 +4142,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "CompositionType",
@@ -4491,7 +4491,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "CustomType",
@@ -5660,7 +5660,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "BooleanTypeDefinition",
@@ -5750,7 +5750,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "StringTypeDefinition",
@@ -5859,7 +5859,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "LargeStringTypeDefinition",
@@ -5958,7 +5958,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "IntegerTypeDefinition",
@@ -6056,7 +6056,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "Integer64TypeDefinition",
@@ -6145,7 +6145,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DecimalTypeDefinition",
@@ -6273,7 +6273,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DoubleTypeDefinition",
@@ -6362,7 +6362,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DateTypeDefinition",
@@ -6457,7 +6457,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "TimeTypeDefinition",
@@ -6546,7 +6546,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "DateTimeTypeDefinition",
@@ -6635,7 +6635,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "TimestampTypeDefinition",
@@ -6724,7 +6724,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "UUIDTypeDefinition",
@@ -6796,7 +6796,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "AssociationTypeDefinition",
@@ -7001,7 +7001,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "CompositionTypeDefinition",
@@ -7199,7 +7199,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "ServiceDefinition",
@@ -7265,7 +7265,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).",
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "ContextDefinition",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -244,7 +244,7 @@
     "Definitions": {
       "title": "Definitions",
       "type": "object",
-      "description": "Each entry in the definitions dictionary is a definition of a named modeling artefact.\nThe `name` is the absolute, fully qualified name of the definition, and the value is a record with the definition details.\n\nDefinition names MUST:\n* Not be an empty string.\n* Not start with `@`, `__`, `.`, `::`.\n* Not end with `.` or `::`.\n* Not contain the substring `..` or `:::`.\n* Not contain the substring `::` more than once.\n\nSee [Primer: Definitions](../primer.md#definitions).",
+      "description": "Each entry in the definitions dictionary is a definition of a named modeling artefact.\nThe `name` is the absolute, fully qualified name of the definition, and the value is a record with the definition details.\n\nDefinition names MUST:\n- Not be an empty string.\n- Not start with `@`, `__`, `.`, `::`.\n- Not end with `.` or `::`.\n- Not contain the substring `..` or `:::`.\n- Not contain the substring `::` more than once.\n\nSee [Primer: Definitions](../primer.md#definitions).",
       "patternProperties": {
         "^(?![@]|__|\\.|::).+$": {
           "$ref": "#/definitions/DefinitionEntry"
@@ -643,7 +643,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -660,7 +660,7 @@
     "ElementDefinitions": {
       "title": "Element Definitions",
       "type": "object",
-      "description": "Dictionary of Element where the key is the name of the element and the value its definition.\n\nThe value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).\n\nElement names MUST:\n* Not be an empty string.\n* Not start with `@`, `__`, `::`.\n* Not end with `::`.\n* Not contain the substring `.` or `:::`.\n* Not contain the substring `::` more than once.",
+      "description": "Dictionary of Element where the key is the name of the element and the value its definition.\n\nThe value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).\n\nElement names MUST:\n- Not be an empty string.\n- Not start with `@`, `__`, `::`.\n- Not end with `::`.\n- Not contain the substring `.` or `:::`.\n- Not contain the substring `::` more than once.",
       "minProperties": 1,
       "patternProperties": {
         "^(?![@]|__|\\.|::).+$": {
@@ -1195,7 +1195,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1438,7 +1438,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1674,7 +1674,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1909,7 +1909,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2142,7 +2142,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2394,7 +2394,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2620,7 +2620,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2853,7 +2853,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3084,7 +3084,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3315,7 +3315,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3546,7 +3546,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3769,7 +3769,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3841,7 +3841,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -4080,7 +4080,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4172,7 +4172,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -4411,7 +4411,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4458,7 +4458,7 @@
     "CustomType": {
       "title": "Custom Type",
       "type": "object",
-      "description": "An Element can be of a Custom Type (aka Derived Type) instead of a standard [CDS type](#cds-type).\nThis allows several Elements to share / reuse the same Custom Type definition.\nThis MAY also imply shared semantics.\n\nThe Custom Type has a custom `type` value, which is the name of the [Type Definition](#type-definition) describing the shared type.\nThis `type` value MUST NOT start with `cds.`, to avoid conflicts with core CDS data types.\n\nThe Type Definition that the Custom Type points to MUST be described in the same CSN document in the [definitions](#definitions) section with `\"kind\": \"type\"`.\nThe [Element](#elemententry) MUST NOT add properties that are not supported by the Custom Types base CDS type.\n\nCSN Interop Effective adds further constraints to make a simple type lookup possible:\n\n* A Custom Type MUST NOT point to another Custom Type (no recursion).\n* The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the \"effective\" quality.\n\nThis will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.\nAll other properties describing the Custom Type can already be found at the Custom Type itself.\n\n> 🚧 TODO: Clarify if Custom Type can also be `cds.Association` or `cds.Composition`.\n> If yes, add `target`, `on` and `cardinality` here.\n",
+      "description": "An Element can be of a Custom Type (aka Derived Type) instead of a standard [CDS type](#cds-type).\nThis allows several Elements to share / reuse the same Custom Type definition.\nThis MAY also imply shared semantics.\n\nThe Custom Type has a custom `type` value, which is the name of the [Type Definition](#type-definition) describing the shared type.\nThis `type` value MUST NOT start with `cds.`, to avoid conflicts with core CDS data types.\n\nThe Type Definition that the Custom Type points to MUST be described in the same CSN document in the [definitions](#definitions) section with `\"kind\": \"type\"`.\nThe [Element](#elemententry) MUST NOT add properties that are not supported by the Custom Types base CDS type.\n\nCSN Interop Effective adds further constraints to make a simple type lookup possible:\n\n- A Custom Type MUST NOT point to another Custom Type (no recursion).\n- The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the \"effective\" quality.\n\nThis will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.\nAll other properties describing the Custom Type can already be found at the Custom Type itself.\n\n> 🚧 TODO: Clarify if Custom Type can also be `cds.Association` or `cds.Composition`.\n> If yes, add `target`, `on` and `cardinality` here.\n",
       "properties": {
         "type": {
           "type": "string",
@@ -4700,7 +4700,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4911,7 +4911,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4938,7 +4938,7 @@
       "oneOf": [
         {
           "const": "floating",
-          "description": "The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the Precision\n\nSee https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale"
+          "description": "The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the `precision`.\n\nSee https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale"
         }
       ],
       "default": "floating",
@@ -4972,7 +4972,7 @@
           ]
         },
         "max": {
-          "description": "Specifies the targets maximum cardinality.\n\nMUST be one of:\n* positive Integer (1,2,...)\n* `*` as String",
+          "description": "Specifies the targets maximum cardinality.\n\nMUST be one of:\n- positive Integer (1,2,...)\n- `*` as String",
           "type": [
             "number",
             "string"
@@ -5011,7 +5011,7 @@
       "properties": {
         "ref": {
           "type": "array",
-          "description": "Description of the target with *association name* and *target element name* in target entity`\nDescription of the source *source element name*\nMUST NOT:\n* use $ as leading character of an element\n* use session variables",
+          "description": "Description of the target with *association name* and *target element name* in target entity`\nDescription of the source *source element name*\n\nMUST NOT:\n- use $ as leading character of an element\n- use session variables",
           "items": {
             "type": "string",
             "x-association-target": [
@@ -5684,7 +5684,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5792,7 +5792,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5901,7 +5901,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5990,7 +5990,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6088,7 +6088,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6205,7 +6205,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6305,7 +6305,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6394,7 +6394,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6489,7 +6489,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6578,7 +6578,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6667,7 +6667,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6748,7 +6748,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -6825,7 +6825,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -6926,7 +6926,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -7030,7 +7030,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -7131,7 +7131,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -7230,7 +7230,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -7287,7 +7287,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -4859,7 +4859,6 @@
     "DefaultValueObject": {
       "title": "Default Value object",
       "type": "object",
-      "description": "Indicates the default value.",
       "properties": {
         "val": {
           "type": [

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -74,7 +74,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown)."
         }
       },
       "additionalProperties": false
@@ -223,7 +223,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "abstract": {
           "type": [
@@ -745,7 +745,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueBoolean"
@@ -936,7 +936,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -1133,7 +1133,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -1334,7 +1334,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueInteger"
@@ -1528,7 +1528,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueInteger"
@@ -1718,7 +1718,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueNumber"
@@ -1928,7 +1928,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueNumber"
@@ -2122,7 +2122,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -2314,7 +2314,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -2506,7 +2506,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -2698,7 +2698,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -2890,7 +2890,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -3071,7 +3071,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "target": {
           "type": "string",
@@ -3365,7 +3365,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "target": {
           "type": "string",
@@ -3667,7 +3667,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueCustomDerived"
@@ -4608,7 +4608,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueBoolean"
@@ -4664,7 +4664,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -4729,7 +4729,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -4784,7 +4784,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueInteger"
@@ -4843,7 +4843,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueInteger"
@@ -4893,7 +4893,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueNumber"
@@ -4972,7 +4972,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueNumber"
@@ -5022,7 +5022,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -5078,7 +5078,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -5128,7 +5128,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -5178,7 +5178,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -5228,7 +5228,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "default": {
           "$ref": "#/definitions/DefaultValueString"
@@ -5271,7 +5271,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "target": {
           "type": "string",
@@ -5434,7 +5434,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "target": {
           "type": "string",
@@ -5592,7 +5592,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "@EndUserText.label": {
           "$ref": "#/definitions/@EndUserText.label"
@@ -5641,7 +5641,7 @@
         },
         "doc": {
           "type": "string",
-          "description": "Human readable documentation.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."
+          "description": "Human readable documentation, usually for developer documentation.\n\nSHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).\n\nIf a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation."
         },
         "@EndUserText.label": {
           "$ref": "#/definitions/@EndUserText.label"

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -99,7 +99,7 @@
     "Definitions": {
       "title": "Definitions",
       "type": "object",
-      "description": "Each entry in the definitions dictionary is a definition of a named modeling artefact.\nThe `name` is the absolute, fully qualified name of the definition, and the value is a record with the definition details.\n\nDefinition names MUST:\n* Not be an empty string.\n* Not start with `@`, `__`, `.`, `::`.\n* Not end with `.` or `::`.\n* Not contain the substring `..` or `:::`.\n* Not contain the substring `::` more than once.\n\nSee [Primer: Definitions](../primer.md#definitions).",
+      "description": "Each entry in the definitions dictionary is a definition of a named modeling artefact.\nThe `name` is the absolute, fully qualified name of the definition, and the value is a record with the definition details.\n\nDefinition names MUST:\n- Not be an empty string.\n- Not start with `@`, `__`, `.`, `::`.\n- Not end with `.` or `::`.\n- Not contain the substring `..` or `:::`.\n- Not contain the substring `::` more than once.\n\nSee [Primer: Definitions](../primer.md#definitions).",
       "patternProperties": {
         "^(?![@]|__|\\.|::).+$": {
           "$ref": "#/definitions/DefinitionEntry"
@@ -399,7 +399,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -412,7 +412,7 @@
     "ElementDefinitions": {
       "title": "Element Definitions",
       "type": "object",
-      "description": "Dictionary of Element where the key is the name of the element and the value its definition.\n\nThe value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).\n\nElement names MUST:\n* Not be an empty string.\n* Not start with `@`, `__`, `::`.\n* Not end with `::`.\n* Not contain the substring `.` or `:::`.\n* Not contain the substring `::` more than once.",
+      "description": "Dictionary of Element where the key is the name of the element and the value its definition.\n\nThe value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).\n\nElement names MUST:\n- Not be an empty string.\n- Not start with `@`, `__`, `::`.\n- Not end with `::`.\n- Not contain the substring `.` or `:::`.\n- Not contain the substring `::` more than once.",
       "minProperties": 1,
       "patternProperties": {
         "^(?![@]|__|\\.|::).+$": {
@@ -898,7 +898,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1097,7 +1097,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1294,7 +1294,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1490,7 +1490,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1684,7 +1684,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -1892,7 +1892,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2084,7 +2084,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2278,7 +2278,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2470,7 +2470,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2662,7 +2662,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -2854,7 +2854,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3043,7 +3043,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3083,7 +3083,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -3317,7 +3317,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3377,7 +3377,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -3611,7 +3611,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3649,7 +3649,7 @@
     "CustomType": {
       "title": "Custom Type",
       "type": "object",
-      "description": "An Element can be of a Custom Type (aka Derived Type) instead of a standard [CDS type](#cds-type).\nThis allows several Elements to share / reuse the same Custom Type definition.\nThis MAY also imply shared semantics.\n\nThe Custom Type has a custom `type` value, which is the name of the [Type Definition](#type-definition) describing the shared type.\nThis `type` value MUST NOT start with `cds.`, to avoid conflicts with core CDS data types.\n\nThe Type Definition that the Custom Type points to MUST be described in the same CSN document in the [definitions](#definitions) section with `\"kind\": \"type\"`.\nThe [Element](#elemententry) MUST NOT add properties that are not supported by the Custom Types base CDS type.\n\nCSN Interop Effective adds further constraints to make a simple type lookup possible:\n\n* A Custom Type MUST NOT point to another Custom Type (no recursion).\n* The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the \"effective\" quality.\n\nThis will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.\nAll other properties describing the Custom Type can already be found at the Custom Type itself.\n\n> 🚧 TODO: Clarify if Custom Type can also be `cds.Association` or `cds.Composition`.\n> If yes, add `target`, `on` and `cardinality` here.\n",
+      "description": "An Element can be of a Custom Type (aka Derived Type) instead of a standard [CDS type](#cds-type).\nThis allows several Elements to share / reuse the same Custom Type definition.\nThis MAY also imply shared semantics.\n\nThe Custom Type has a custom `type` value, which is the name of the [Type Definition](#type-definition) describing the shared type.\nThis `type` value MUST NOT start with `cds.`, to avoid conflicts with core CDS data types.\n\nThe Type Definition that the Custom Type points to MUST be described in the same CSN document in the [definitions](#definitions) section with `\"kind\": \"type\"`.\nThe [Element](#elemententry) MUST NOT add properties that are not supported by the Custom Types base CDS type.\n\nCSN Interop Effective adds further constraints to make a simple type lookup possible:\n\n- A Custom Type MUST NOT point to another Custom Type (no recursion).\n- The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the \"effective\" quality.\n\nThis will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.\nAll other properties describing the Custom Type can already be found at the Custom Type itself.\n\n> 🚧 TODO: Clarify if Custom Type can also be `cds.Association` or `cds.Composition`.\n> If yes, add `target`, `on` and `cardinality` here.\n",
       "properties": {
         "type": {
           "type": "string",
@@ -3846,7 +3846,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -3990,7 +3990,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4009,7 +4009,7 @@
       "oneOf": [
         {
           "const": "floating",
-          "description": "The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the Precision\n\nSee https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale"
+          "description": "The value floating means that the decimal property represents a decimal floating-point number whose number of significant digits is the value of the `precision`.\n\nSee https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale"
         }
       ],
       "default": "floating"
@@ -4029,7 +4029,7 @@
           "default": 0
         },
         "max": {
-          "description": "Specifies the targets maximum cardinality.\n\nMUST be one of:\n* positive Integer (1,2,...)\n* `*` as String",
+          "description": "Specifies the targets maximum cardinality.\n\nMUST be one of:\n- positive Integer (1,2,...)\n- `*` as String",
           "type": [
             "number",
             "string"
@@ -4055,7 +4055,7 @@
       "properties": {
         "ref": {
           "type": "array",
-          "description": "Description of the target with *association name* and *target element name* in target entity`\nDescription of the source *source element name*\nMUST NOT:\n* use $ as leading character of an element\n* use session variables",
+          "description": "Description of the target with *association name* and *target element name* in target entity`\nDescription of the source *source element name*\n\nMUST NOT:\n- use $ as leading character of an element\n- use session variables",
           "items": {
             "type": "string"
           }
@@ -4622,7 +4622,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4686,7 +4686,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4751,7 +4751,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4801,7 +4801,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4860,7 +4860,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4928,7 +4928,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -4989,7 +4989,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5039,7 +5039,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5095,7 +5095,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5145,7 +5145,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5195,7 +5195,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5242,7 +5242,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5282,7 +5282,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -5378,7 +5378,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5445,7 +5445,7 @@
         },
         "on": {
           "type": "array",
-          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\n\nIn addition, several building blocks can be lined up using an \"and\" operator\n\nMore information can be found here:\n* https://cap.cloud.sap/docs/cds/csn#assoc-on",
+          "description": "The property `on` holds a sequence of operators and operands to describe the join condition.\n\nOne building block of the sequence consists of the following in the given order:\n- Reference to a field of the association or composition target\n- Equals Operator \"=\"\n- One of the following:\n  - Reference to a field of the source entity\n  - Constant Value\n\nThis building block states that the value of the first entry of the array using \"ref\" should equal the value of the third entry of the array.\nIn addition, several building blocks can be lined up using an \"and\" operator.\n\nSee also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).",
           "items": {
             "oneOf": [
               {
@@ -5541,7 +5541,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5618,7 +5618,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },
@@ -5658,7 +5658,7 @@
             "array",
             "object"
           ],
-          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n* `\"@Common.bar\": \"foo\"`\n* `\"@Common.foo.bar\": true`\n* `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
+          "description": "Annotations or private properties MAY be added.\n\n**Annotations** MUST start with `@`.\n\nIn CSN Interop Effective the annotations MUST follow the \"flattened\" form:\nEvery record / object in an annotation will be flattened into a `.` (dot).\nException: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are (\"structured\").\n\nCorrect annotations examples:\n- `\"@Common.bar\": \"foo\"`\n- `\"@Common.foo.bar\": true`\n- `\"@Common.array\": [{ \"foo\": true }]`\n\nOr\n\n**Private properties**, starting with `__`.\nMAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.",
           "tsType": "unknown // replaceKeyType_{PrivatePropertyKey|AnnotationPropertyKey}"
         }
       },

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -67,6 +67,11 @@
             "1.3.4"
           ]
         },
+        "title": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "Human readable title for the CSN document (plain-text)."
+        },
         "doc": {
           "type": "string",
           "description": "Human readable documentation that describes the overall CSN document.\n\nSHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown)."

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -3952,7 +3952,6 @@
     "DefaultValueObject": {
       "title": "Default Value object",
       "type": "object",
-      "description": "Indicates the default value.",
       "properties": {
         "val": {
           "type": [

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -390,7 +390,7 @@ export interface DocumentMetadata {
   /**
    * Human readable documentation that describes the overall CSN document.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
    */
   doc?: string;
 }
@@ -431,9 +431,11 @@ export interface ContextDefinition {
    */
   kind: ContextKind;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   "@EndUserText.label"?: EndUserTextLabel;
@@ -475,9 +477,11 @@ export interface EntityDefinition {
   kind: EntityKind;
   elements: ElementDefinitions;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   /**
@@ -676,9 +680,11 @@ export interface BooleanType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueBoolean;
@@ -885,9 +891,11 @@ export interface StringType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1026,9 +1034,11 @@ export interface LargeStringType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1126,9 +1136,11 @@ export interface IntegerType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueInteger;
@@ -1227,9 +1239,11 @@ export interface Integer64Type {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueInteger;
@@ -1317,9 +1331,11 @@ export interface DecimalType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueNumber;
@@ -1424,9 +1440,11 @@ export interface DoubleType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueNumber;
@@ -1519,9 +1537,11 @@ export interface DateType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1614,9 +1634,11 @@ export interface TimeType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1709,9 +1731,11 @@ export interface DateTimeType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1804,9 +1828,11 @@ export interface TimestampType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1899,9 +1925,11 @@ export interface UUIDType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -1987,9 +2015,11 @@ export interface AssociationType {
    */
   type: AssociationCdsType;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   /**
@@ -2143,9 +2173,11 @@ export interface CompositionType {
    */
   type: CompositionCdsType;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   /**
@@ -2303,9 +2335,11 @@ export interface CustomType {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueCustomType;
@@ -2619,9 +2653,11 @@ export interface ServiceDefinition {
    */
   kind: ServiceKind;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   "@EndUserText.label"?: EndUserTextLabel;
@@ -2667,9 +2703,11 @@ export interface BooleanTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueBoolean;
@@ -2711,9 +2749,11 @@ export interface StringTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -2761,9 +2801,11 @@ export interface LargeStringTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -2811,9 +2853,11 @@ export interface IntegerTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueInteger;
@@ -2856,9 +2900,11 @@ export interface Integer64TypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueInteger;
@@ -2901,9 +2947,11 @@ export interface DecimalTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueNumber;
@@ -2957,9 +3005,11 @@ export interface DoubleTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueNumber;
@@ -3002,9 +3052,11 @@ export interface DateTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -3047,9 +3099,11 @@ export interface TimeTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -3092,9 +3146,11 @@ export interface DateTimeTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -3137,9 +3193,11 @@ export interface TimestampTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -3182,9 +3240,11 @@ export interface UUIDTypeDefinition {
    */
   notNull?: boolean;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   default?: DefaultValueString;
@@ -3222,9 +3282,11 @@ export interface AssociationTypeDefinition {
    */
   type: AssociationCdsType;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   /**
@@ -3308,9 +3370,11 @@ export interface CompositionTypeDefinition {
    */
   type: CompositionCdsType;
   /**
-   * Human readable documentation.
+   * Human readable documentation, usually for developer documentation.
    *
-   * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   * SHOULD be provided and interpreted as [CommonMark](https://spec.commonmark.org/) (Markdown).
+   *
+   * If a human readable title is needed, use the [@EndUserText.label](../annotations/enduser-text#endusertextlabel) annotation.
    */
   doc?: string;
   /**

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -382,6 +382,10 @@ export interface DocumentMetadata {
    */
   version?: string;
   /**
+   * Human readable title for the CSN document (plain-text).
+   */
+  title?: string;
+  /**
    * Human readable documentation that describes the overall CSN document.
    *
    * SHOULD be provided and rendered as [CommonMark](https://spec.commonmark.org/) (Markdown).

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -450,9 +450,9 @@ export interface ContextDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -636,9 +636,9 @@ export interface EntityDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -653,11 +653,11 @@ export interface EntityDefinition {
  * The value can either be a standard [CDS Type](#cds-type) (`cds.*`) or a [Custom Type](#custom-type).
  *
  * Element names MUST:
- * * Not be an empty string.
- * * Not start with `@`, `__`, `::`.
- * * Not end with `::`.
- * * Not contain the substring `.` or `:::`.
- * * Not contain the substring `::` more than once.
+ * - Not be an empty string.
+ * - Not start with `@`, `__`, `::`.
+ * - Not end with `::`.
+ * - Not contain the substring `.` or `:::`.
+ * - Not contain the substring `::` more than once.
  */
 export interface ElementDefinitions {
   [k: string]: ElementEntry;
@@ -747,9 +747,9 @@ export interface BooleanType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -964,9 +964,9 @@ export interface StringType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1010,9 +1010,9 @@ export interface ValueObject {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1107,9 +1107,9 @@ export interface LargeStringType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1204,9 +1204,9 @@ export interface IntegerType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1307,9 +1307,9 @@ export interface Integer64Type {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1410,9 +1410,9 @@ export interface DecimalType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1508,9 +1508,9 @@ export interface DoubleType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1605,9 +1605,9 @@ export interface DateType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1702,9 +1702,9 @@ export interface TimeType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1799,9 +1799,9 @@ export interface DateTimeType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1896,9 +1896,9 @@ export interface TimestampType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -1992,9 +1992,9 @@ export interface UUIDType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2036,12 +2036,11 @@ export interface AssociationType {
    * - One of the following:
    *   - Reference to a field of the source entity
    *   - Constant Value
+   *
    * This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
+   * In addition, several building blocks can be lined up using an "and" operator.
    *
-   * In addition, several building blocks can be lined up using an "and" operator
-   *
-   * More information can be found here:
-   * * https://cap.cloud.sap/docs/cds/csn#assoc-on
+   * See also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).
    */
   on: (StructuredElementReference | EqualsOperator | ANDOperator | OnValue)[];
   "@Aggregation.default"?: Aggregation;
@@ -2103,9 +2102,9 @@ export interface AssociationType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2134,8 +2133,8 @@ export interface CardinalityObject {
    * Specifies the targets maximum cardinality.
    *
    * MUST be one of:
-   * * positive Integer (1,2,...)
-   * * `*` as String
+   * - positive Integer (1,2,...)
+   * - `*` as String
    */
   max?: number | string;
 }
@@ -2146,9 +2145,10 @@ export interface StructuredElementReference {
   /**
    * Description of the target with *association name* and *target element name* in target entity`
    * Description of the source *source element name*
+   *
    * MUST NOT:
-   * * use $ as leading character of an element
-   * * use session variables
+   * - use $ as leading character of an element
+   * - use session variables
    */
   ref: string[];
 }
@@ -2194,12 +2194,11 @@ export interface CompositionType {
    * - One of the following:
    *   - Reference to a field of the source entity
    *   - Constant Value
+   *
    * This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
+   * In addition, several building blocks can be lined up using an "and" operator.
    *
-   * In addition, several building blocks can be lined up using an "and" operator
-   *
-   * More information can be found here:
-   * * https://cap.cloud.sap/docs/cds/csn#assoc-on
+   * See also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).
    */
   on: (StructuredElementReference | EqualsOperator | ANDOperator | OnValue)[];
   "@Aggregation.default"?: Aggregation;
@@ -2261,9 +2260,9 @@ export interface CompositionType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2292,8 +2291,8 @@ export interface CardinalityObject1 {
    * Specifies the targets maximum cardinality.
    *
    * MUST be one of:
-   * * positive Integer (1,2,...)
-   * * `*` as String
+   * - positive Integer (1,2,...)
+   * - `*` as String
    */
   max?: number | string;
 }
@@ -2310,8 +2309,8 @@ export interface CardinalityObject1 {
  *
  * CSN Interop Effective adds further constraints to make a simple type lookup possible:
  *
- * * A Custom Type MUST NOT point to another Custom Type (no recursion).
- * * The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the "effective" quality.
+ * - A Custom Type MUST NOT point to another Custom Type (no recursion).
+ * - The properties and annotations of the Custom Type MUST be merged into the Element it is used, to fulfill the "effective" quality.
  *
  * This will allow a consumer to do a simple dictionary lookup to find the [CDS Type](#cds-type) of a Custom Type.
  * All other properties describing the Custom Type can already be found at the Custom Type itself.
@@ -2419,9 +2418,9 @@ export interface CustomType {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2675,9 +2674,9 @@ export interface ServiceDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2721,9 +2720,9 @@ export interface BooleanTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2773,9 +2772,9 @@ export interface StringTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2825,9 +2824,9 @@ export interface LargeStringTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2872,9 +2871,9 @@ export interface IntegerTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2919,9 +2918,9 @@ export interface Integer64TypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -2977,9 +2976,9 @@ export interface DecimalTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3024,9 +3023,9 @@ export interface DoubleTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3071,9 +3070,9 @@ export interface DateTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3118,9 +3117,9 @@ export interface TimeTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3165,9 +3164,9 @@ export interface DateTimeTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3212,9 +3211,9 @@ export interface TimestampTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3258,9 +3257,9 @@ export interface UUIDTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3303,12 +3302,11 @@ export interface AssociationTypeDefinition {
    * - One of the following:
    *   - Reference to a field of the source entity
    *   - Constant Value
+   *
    * This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
+   * In addition, several building blocks can be lined up using an "and" operator.
    *
-   * In addition, several building blocks can be lined up using an "and" operator
-   *
-   * More information can be found here:
-   * * https://cap.cloud.sap/docs/cds/csn#assoc-on
+   * See also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).
    */
   on: (StructuredElementReference | EqualsOperator | ANDOperator | OnValue)[];
   /**
@@ -3321,9 +3319,9 @@ export interface AssociationTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3352,8 +3350,8 @@ export interface CardinalityObject2 {
    * Specifies the targets maximum cardinality.
    *
    * MUST be one of:
-   * * positive Integer (1,2,...)
-   * * `*` as String
+   * - positive Integer (1,2,...)
+   * - `*` as String
    */
   max?: number | string;
 }
@@ -3391,12 +3389,11 @@ export interface CompositionTypeDefinition {
    * - One of the following:
    *   - Reference to a field of the source entity
    *   - Constant Value
+   *
    * This building block states that the value of the first entry of the array using "ref" should equal the value of the third entry of the array.
+   * In addition, several building blocks can be lined up using an "and" operator.
    *
-   * In addition, several building blocks can be lined up using an "and" operator
-   *
-   * More information can be found here:
-   * * https://cap.cloud.sap/docs/cds/csn#assoc-on
+   * See also [CAP documentation](https://cap.cloud.sap/docs/cds/csn#assoc-on).
    */
   on: (StructuredElementReference | EqualsOperator | ANDOperator | OnValue)[];
   /**
@@ -3409,9 +3406,9 @@ export interface CompositionTypeDefinition {
    * Exception: Once there is an array, the flattening is stopped and the values inside the array are preserved as they are ("structured").
    *
    * Correct annotations examples:
-   * * `"@Common.bar": "foo"`
-   * * `"@Common.foo.bar": true`
-   * * `"@Common.array": [{ "foo": true }]`
+   * - `"@Common.bar": "foo"`
+   * - `"@Common.foo.bar": true`
+   * - `"@Common.array": [{ "foo": true }]`
    *
    * Or
    *
@@ -3440,8 +3437,8 @@ export interface CardinalityObject3 {
    * Specifies the targets maximum cardinality.
    *
    * MUST be one of:
-   * * positive Integer (1,2,...)
-   * * `*` as String
+   * - positive Integer (1,2,...)
+   * - `*` as String
    */
   max?: number | string;
 }


### PR DESCRIPTION
To give the overall document not just a description `doc`, but also a human readable `title`.