### PR TITLE
Fix x-ref-to-doc not creating ref on final output JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,18 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [0.4.0]
 
+### Added
+
 - ADDED: Clear statement that `ElementRef` referenced element MUST exist locally in the same entity.
 - ADDED: `meta.document.title` to give the overall document a human-readable title
+-
+
+### Changed
+
 - BREAKING: wrong @Semantics.amountCurrencyCode annotation, should be @Semantics.amount.currencyCode
 - BREAKING: wrong @Semantics.quantityUnitOfMeasure annotation, should be @Semantics.quantity.unitOfMeasure
 - BREAKING: For custom types, we should not set `key` property - as this is decided on entity element level.
+- FIXED: JSON Schema export $ref from annotation extensions back to core spec (`ElementReference`) was missing.
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [0.4.0]
 
+- ADDED: Clear statement that `ElementRef` referenced element MUST exist locally in the same entity.
 - ADDED: `meta.document.title` to give the overall document a human-readable title
 - BREAKING: wrong @Semantics.amountCurrencyCode annotation, should be @Semantics.amount.currencyCode
 - BREAKING: wrong @Semantics.quantityUnitOfMeasure annotation, should be @Semantics.quantity.unitOfMeasure

--- a/spec/annotations/consumption.yaml
+++ b/spec/annotations/consumption.yaml
@@ -1,5 +1,4 @@
 $schema: "http://json-schema.org/draft-07/schema#"
-$id: "https://sap.github.io/csn-interop-specification/spec-v1/consumption.schema.json#"
 title: "Consumption"
 x-extension:
   targetDocument: "./spec/v1/CSN-Interop-Effective.schema.yaml"

--- a/spec/annotations/consumption.yaml
+++ b/spec/annotations/consumption.yaml
@@ -1,4 +1,5 @@
 $schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://sap.github.io/csn-interop-specification/spec-v1/consumption.schema.json#"
 title: "Consumption"
 x-extension:
   targetDocument: "./spec/v1/CSN-Interop-Effective.schema.yaml"

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -73,7 +73,7 @@ definitions:
 
           See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
         anyOf:
-          - const: https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json
+          - const: https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#
           - type: string
             format: uri-reference
       $id:
@@ -106,7 +106,6 @@ definitions:
 
       definitions:
         $ref: "#/definitions/Definitions"
-        $ref-type: "composition"
         description: |
           Dictionary of CSN modeling artifacts.
 

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -1450,9 +1450,9 @@ definitions:
   ElementReference:
     title: Element Reference
     description: |-
-      Element reference denotes a reference to an element.
+      Element reference to an element within the current entity.
 
-      It is RECOMMENDED to use the ElementReferenceObject notation.
+      It is RECOMMENDED to use the [ElementReferenceObject](#element-reference-object) notation.
 
       See [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).
 
@@ -1464,7 +1464,10 @@ definitions:
     title: Element Reference String
     type: string
     description: |-
-      Element reference denotes a reference to an element, i.e. a member of the elements object of an entity in the following format:
+      Element reference to an element within the current entity, using string notation.
+
+      The referenced element MUST exist locally in the same entity.
+
       ```js
       "<definition name>": {
         "<annotation key of type ElementReference>": "<element name>"
@@ -1474,7 +1477,9 @@ definitions:
     title: Element Reference Object
     type: object
     description: |-
-      Element reference denotes a reference to an element, i.e. a member fo the elements object of an entity in the following format:
+      Element reference to an element within the current entity, using RECOMMENDED object notation.
+
+      The referenced element MUST exist locally in the same entity.
 
       ```js
       "<definition name>": {

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -1,5 +1,5 @@
 $schema: "http://json-schema.org/draft-07/schema#"
-$id: "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+$id: "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#"
 title: CSN Interop Effective
 description: |-
   This is the interface description of CSN Interop Effective v1.
@@ -106,6 +106,7 @@ definitions:
 
       definitions:
         $ref: "#/definitions/Definitions"
+        $ref-type: "composition"
         description: |
           Dictionary of CSN modeling artifacts.
 
@@ -1063,7 +1064,6 @@ definitions:
           - "#/definitions/EntityDefinition"
 
       cardinality:
-        type: object
         $ref: "#/definitions/CardinalityObject"
 
       "on": &on
@@ -1156,7 +1156,6 @@ definitions:
           - "#/definitions/EntityDefinition"
 
       cardinality:
-        type: object
         $ref: "#/definitions/CardinalityObject"
 
       on: *on

--- a/src/spec-toolkit/generateInterfaceDocumentation.ts
+++ b/src/spec-toolkit/generateInterfaceDocumentation.ts
@@ -35,7 +35,7 @@ import {
   ensureRootLevelSchema,
   removeDescriptionsFromRefPointers,
   removeExtensionAttributes,
-  postprocessSpecJsonSchema,
+  convertRefToDocToStandardRef,
 } from "./util/jsonSchemaConversion";
 
 import _ from "lodash";
@@ -188,8 +188,6 @@ function jsonSchemaToDocumentation(docConfig: DocsConfig, docsConfigs: DocsConfi
     jsonSchemaRoot = ensureRootLevelSchema(jsonSchemaRoot);
   }
 
-  jsonSchemaRoot = postprocessSpecJsonSchema(jsonSchemaRoot)
-
   writeSpecJsonSchemaFiles(docConfig.targetFolder || "src/spec-v1", outputFileName, jsonSchemaRoot);
 
   log.info("--------------------------------------------------------------------------");
@@ -270,7 +268,6 @@ function handleRefToCore(jsonSchemaObject: SpecJsonSchema, docsConfigs: DocsConf
   const refToDoc =
     typeof jsonSchemaObject === "object" && "x-ref-to-doc" in jsonSchemaObject ? jsonSchemaObject["x-ref-to-doc"] : "";
   if (refToDoc) {
-    jsonSchemaObject.$ref = jsonSchemaObject["x-ref-to-doc"]?.ref
     let refToDocTitle = "";
     let refToDocDocId = "";
     let refToDocDoc = "";
@@ -1293,6 +1290,9 @@ export function getAnyOfDescription(jsonSchemaObject: SpecJsonSchema, title = "R
 ////////////////////////////////////////////////////////////
 
 export function writeSpecJsonSchemaFiles(path: string, outputFileName: string, jsonSchema: SpecJsonSchemaRoot): void {
+
+  jsonSchema = convertRefToDocToStandardRef(jsonSchema);
+
   // TODO: Refactor making the outputFileName fully configurable, also whether to to generate "annotated" or not.
   const jsonSchemaPublishedPath = `${path}/${outputFileName}.schema.json`;
   // First write it as .annotated.schema file that includes all the x- extensions

--- a/src/spec-toolkit/generateInterfaceDocumentation.ts
+++ b/src/spec-toolkit/generateInterfaceDocumentation.ts
@@ -35,6 +35,7 @@ import {
   ensureRootLevelSchema,
   removeDescriptionsFromRefPointers,
   removeExtensionAttributes,
+  postprocessSpecJsonSchema,
 } from "./util/jsonSchemaConversion";
 
 import _ from "lodash";
@@ -187,6 +188,8 @@ function jsonSchemaToDocumentation(docConfig: DocsConfig, docsConfigs: DocsConfi
     jsonSchemaRoot = ensureRootLevelSchema(jsonSchemaRoot);
   }
 
+  jsonSchemaRoot = postprocessSpecJsonSchema(jsonSchemaRoot)
+
   writeSpecJsonSchemaFiles(docConfig.targetFolder || "src/spec-v1", outputFileName, jsonSchemaRoot);
 
   log.info("--------------------------------------------------------------------------");
@@ -267,6 +270,7 @@ function handleRefToCore(jsonSchemaObject: SpecJsonSchema, docsConfigs: DocsConf
   const refToDoc =
     typeof jsonSchemaObject === "object" && "x-ref-to-doc" in jsonSchemaObject ? jsonSchemaObject["x-ref-to-doc"] : "";
   if (refToDoc) {
+    jsonSchemaObject.$ref = jsonSchemaObject["x-ref-to-doc"]?.ref
     let refToDocTitle = "";
     let refToDocDocId = "";
     let refToDocDoc = "";

--- a/src/spec-toolkit/generateTypeScriptDefinitions.ts
+++ b/src/spec-toolkit/generateTypeScriptDefinitions.ts
@@ -3,6 +3,7 @@ import {
   convertAnyOfEnum,
   convertOneOfEnum,
   ensureRootLevelSchema,
+  convertRefToDocToStandardRef,
   removeDescriptionsFromRefPointers,
   removeExtensionAttributes,
 } from "./util/jsonSchemaConversion";
@@ -19,6 +20,7 @@ export async function generateTypeScriptDefinitions(schemaName: string, schema?:
     schema = yaml.load(fs.readFileSync(`./spec/v1/${schemaName}.schema.yaml`).toString()) as SpecJsonSchemaRoot;
   }
 
+  schema = convertRefToDocToStandardRef(schema);
   schema = convertOneOfEnum(schema);
   schema = convertAnyOfEnum(schema);
   schema = convertAllOfWithIfThenDiscriminatorToOneOf(schema);

--- a/src/spec-toolkit/util/jsonSchemaConversion.ts
+++ b/src/spec-toolkit/util/jsonSchemaConversion.ts
@@ -51,7 +51,7 @@ export function preprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot, jsonSch
 /**
  * Postprocess a Spec JSON Schema file, for final export
  */
-export function postprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot): SpecJsonSchemaRoot {
+export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): SpecJsonSchemaRoot {
   // Deep clone, just to avoid accidental mutations of input
   let result = JSON.parse(JSON.stringify(jsonSchema))
   result.definitions = result.definitions || {};

--- a/src/spec-toolkit/util/jsonSchemaConversion.ts
+++ b/src/spec-toolkit/util/jsonSchemaConversion.ts
@@ -49,7 +49,8 @@ export function preprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot, jsonSch
 }
 
 /**
- * Postprocess a Spec JSON Schema file, for final export
+ * Convert x-ref-to-doc- to proper $ref
+ * Also removes `description` on same level, as a $ref should be the only property of the object
  */
 export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): SpecJsonSchemaRoot {
   // Deep clone, just to avoid accidental mutations of input
@@ -57,12 +58,17 @@ export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): Sp
   result.definitions = result.definitions || {};
   for (const definitionName in result.definitions) {
     const definition = result.definitions[definitionName];
+    if (definition["x-ref-to-doc"]) {
+      definition.$ref = definition["x-ref-to-doc"].ref;
+      delete definition.description;
+    }
+
     if (definition.properties) {
       for (const propertyName in definition.properties) {
         const property = definition.properties[propertyName] as SpecJsonSchemaRoot;
-        // Convert x-ref-to-doc- to proper $ref
         if (property["x-ref-to-doc"]) {
           property.$ref = property["x-ref-to-doc"].ref;
+          delete property.description;
         }
       }
     }

--- a/src/spec-toolkit/util/jsonSchemaConversion.ts
+++ b/src/spec-toolkit/util/jsonSchemaConversion.ts
@@ -50,7 +50,9 @@ export function preprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot, jsonSch
 
 /**
  * Convert x-ref-to-doc- to proper $ref
- * Also removes `description` on same level, as a $ref should be the only property of the object
+ * 
+ * So far we use x-ref-to-doc to create a link from a spec extension back to the core spec
+ * After we merge the extensions and the core spec into one JSON Schema file, we can use a standard (local) $ref pointer 
  */
 export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): SpecJsonSchemaRoot {
   // Deep clone, just to avoid accidental mutations of input
@@ -60,7 +62,6 @@ export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): Sp
     const definition = result.definitions[definitionName];
     if (definition["x-ref-to-doc"]) {
       definition.$ref = definition["x-ref-to-doc"].ref;
-      delete definition.description;
     }
 
     if (definition.properties) {
@@ -68,7 +69,6 @@ export function convertRefToDocToStandardRef(jsonSchema: SpecJsonSchemaRoot): Sp
         const property = definition.properties[propertyName] as SpecJsonSchemaRoot;
         if (property["x-ref-to-doc"]) {
           property.$ref = property["x-ref-to-doc"].ref;
-          delete property.description;
         }
       }
     }
@@ -238,6 +238,9 @@ export function removeDescriptionsFromRefPointers(jsonSchema: SpecJsonSchemaRoot
   if (jsonSchema.definitions) {
     for (const definitionName in jsonSchema.definitions) {
       const definition = jsonSchema.definitions[definitionName];
+      if (definition.$ref && definition.description) {
+        delete definition.description;
+      }
       if (definition.properties) {
         for (const propertyName in definition.properties) {
           const property = definition.properties[propertyName];

--- a/src/spec-toolkit/util/jsonSchemaConversion.ts
+++ b/src/spec-toolkit/util/jsonSchemaConversion.ts
@@ -49,6 +49,29 @@ export function preprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot, jsonSch
 }
 
 /**
+ * Postprocess a Spec JSON Schema file, for final export
+ */
+export function postprocessSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot): SpecJsonSchemaRoot {
+  // Deep clone, just to avoid accidental mutations of input
+  let result = JSON.parse(JSON.stringify(jsonSchema))
+  result.definitions = result.definitions || {};
+  for (const definitionName in result.definitions) {
+    const definition = result.definitions[definitionName];
+    if (definition.properties) {
+      for (const propertyName in definition.properties) {
+        const property = definition.properties[propertyName] as SpecJsonSchemaRoot;
+        // Convert x-ref-to-doc- to proper $ref
+        if (property["x-ref-to-doc"]) {
+          property.$ref = property["x-ref-to-doc"].ref;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
  * Workaround for enums expressed as oneOf const
  * -> oneOf is not well presented in SwaggerUI
  * -> oneOf is not supported by the JSON Schema to TS library

--- a/src/spec-v1/consumption.annotated.schema.json
+++ b/src/spec-v1/consumption.annotated.schema.json
@@ -57,7 +57,8 @@
             "./spec/annotations/consumption.yaml",
             "@Consumption.ConsumptionValueHelpDefinition",
             "association"
-          ]
+          ],
+          "$ref": "#/definitions/ElementReference"
         },
         "distinctValues": {
           "type": "boolean",

--- a/src/spec-v1/consumption.annotated.schema.json
+++ b/src/spec-v1/consumption.annotated.schema.json
@@ -1,6 +1,7 @@
 {
   "description": "JSON Schema with custom (x-) annotations",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/consumption.schema.json#",
   "title": "Consumption",
   "x-extension": {
     "targetDocument": "./spec/v1/CSN-Interop-Effective.schema.yaml",

--- a/src/spec-v1/consumption.annotated.schema.json
+++ b/src/spec-v1/consumption.annotated.schema.json
@@ -52,7 +52,6 @@
             "title": "Element Reference",
             "ref": "#/definitions/ElementReference"
           },
-          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`.",
           "x-context": [
             "./spec/annotations/consumption.yaml",
             "@Consumption.ConsumptionValueHelpDefinition",

--- a/src/spec-v1/consumption.annotated.schema.json
+++ b/src/spec-v1/consumption.annotated.schema.json
@@ -52,6 +52,7 @@
             "title": "Element Reference",
             "ref": "#/definitions/ElementReference"
           },
+          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`.",
           "x-context": [
             "./spec/annotations/consumption.yaml",
             "@Consumption.ConsumptionValueHelpDefinition",

--- a/src/spec-v1/consumption.annotated.schema.json
+++ b/src/spec-v1/consumption.annotated.schema.json
@@ -1,7 +1,6 @@
 {
   "description": "JSON Schema with custom (x-) annotations",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/consumption.schema.json#",
   "title": "Consumption",
   "x-extension": {
     "targetDocument": "./spec/v1/CSN-Interop-Effective.schema.yaml",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -7470,7 +7470,6 @@
             "title": "Element Reference",
             "ref": "#/definitions/ElementReference"
           },
-          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`.",
           "$ref": "#/definitions/ElementReference"
         },
         "distinctValues": {
@@ -7963,7 +7962,6 @@
       ]
     },
     "@ObjectModel.representativeKey": {
-      "description": "In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)",
       "x-extension-targets": [
         "Entity",
         "Service"
@@ -8049,7 +8047,6 @@
       }
     },
     "@ObjectModel.foreignKey.association": {
-      "description": "The element is of type `cds.Association` which points to the list of values. \n\nUse only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.",
       "x-extension-targets": [
         "Type"
       ],
@@ -8078,7 +8075,6 @@
       ]
     },
     "@ObjectModel.text.association": {
-      "description": "The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element",
       "x-extension-targets": [
         "Type"
       ],
@@ -8141,7 +8137,6 @@
       ]
     },
     "@ODM.oid": {
-      "description": "The annotation references the element which contains the oid.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -8267,7 +8262,6 @@
       ]
     },
     "@Semantics.amount.currencyCode": {
-      "description": "The element contains an amount. The annotation points to an element containing the currency code.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -8286,7 +8280,6 @@
       ]
     },
     "@Semantics.quantity.unitOfMeasure": {
-      "description": "The element contains a quantity.\nThe annotation points to an element containing the unit of measure.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -1,7 +1,7 @@
 {
   "description": "Root of the CSN Interop Effective JSON document.\n\nSee [Primer: Root Level Structure](../primer.md#root-level-structure).",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
+  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#",
   "title": "CSN Interop Root",
   "x-custom-typescript-types": [
     {
@@ -3834,7 +3834,6 @@
           ]
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
@@ -4165,7 +4164,6 @@
           ]
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
@@ -6818,7 +6816,6 @@
           ]
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
@@ -7023,7 +7020,6 @@
           ]
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
@@ -8576,6 +8572,7 @@
     },
     "definitions": {
       "$ref": "#/definitions/Definitions",
+      "$ref-type": "composition",
       "description": "Dictionary of CSN modeling artifacts.\n",
       "x-context": [
         "./spec/v1/CSN-Interop-Effective.schema.yaml",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -7470,6 +7470,7 @@
             "title": "Element Reference",
             "ref": "#/definitions/ElementReference"
           },
+          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`.",
           "$ref": "#/definitions/ElementReference"
         },
         "distinctValues": {
@@ -7962,6 +7963,7 @@
       ]
     },
     "@ObjectModel.representativeKey": {
+      "description": "In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)",
       "x-extension-targets": [
         "Entity",
         "Service"
@@ -8047,6 +8049,7 @@
       }
     },
     "@ObjectModel.foreignKey.association": {
+      "description": "The element is of type `cds.Association` which points to the list of values. \n\nUse only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.",
       "x-extension-targets": [
         "Type"
       ],
@@ -8075,6 +8078,7 @@
       ]
     },
     "@ObjectModel.text.association": {
+      "description": "The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element",
       "x-extension-targets": [
         "Type"
       ],
@@ -8137,6 +8141,7 @@
       ]
     },
     "@ODM.oid": {
+      "description": "The annotation references the element which contains the oid.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -8262,6 +8267,7 @@
       ]
     },
     "@Semantics.amount.currencyCode": {
+      "description": "The element contains an amount. The annotation points to an element containing the currency code.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -8280,6 +8286,7 @@
       ]
     },
     "@Semantics.quantity.unitOfMeasure": {
+      "description": "The element contains a quantity.\nThe annotation points to an element containing the unit of measure.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -8513,7 +8513,7 @@
       "description": "Link to JSON Schema for this CSN Interop Effective document.\nAdding this helps with automatic validation and code intelligence in some editors / IDEs.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
       "anyOf": [
         {
-          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#"
         },
         {
           "type": "string",
@@ -8572,7 +8572,6 @@
     },
     "definitions": {
       "$ref": "#/definitions/Definitions",
-      "$ref-type": "composition",
       "description": "Dictionary of CSN modeling artifacts.\n",
       "x-context": [
         "./spec/v1/CSN-Interop-Effective.schema.yaml",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -5114,7 +5114,7 @@
     },
     "ElementReference": {
       "title": "Element Reference",
-      "description": "Element reference denotes a reference to an element.\n\nIt is RECOMMENDED to use the ElementReferenceObject notation.\n\nSee [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).",
+      "description": "Element reference to an element within the current entity.\n\nIt is RECOMMENDED to use the [ElementReferenceObject](#element-reference-object) notation.\n\nSee [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).",
       "oneOf": [
         {
           "$ref": "#/definitions/ElementReferenceString"
@@ -5131,7 +5131,7 @@
     "ElementReferenceString": {
       "title": "Element Reference String",
       "type": "string",
-      "description": "Element reference denotes a reference to an element, i.e. a member of the elements object of an entity in the following format:\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": \"<element name>\"\n```",
+      "description": "Element reference to an element within the current entity, using string notation.\n\nThe referenced element MUST exist locally in the same entity.\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": \"<element name>\"\n```",
       "x-context": [
         "./spec/v1/CSN-Interop-Effective.schema.yaml",
         "ElementReferenceString"
@@ -5140,7 +5140,7 @@
     "ElementReferenceObject": {
       "title": "Element Reference Object",
       "type": "object",
-      "description": "Element reference denotes a reference to an element, i.e. a member fo the elements object of an entity in the following format:\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": {\"=\": \"<element name>\"}\n```",
+      "description": "Element reference to an element within the current entity, using RECOMMENDED object notation.\n\nThe referenced element MUST exist locally in the same entity.\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": {\"=\": \"<element name>\"}\n```",
       "properties": {
         "=": {
           "type": "string",

--- a/src/spec-v1/csn-interop-effective.annotated.schema.json
+++ b/src/spec-v1/csn-interop-effective.annotated.schema.json
@@ -126,6 +126,7 @@
         },
         "document": {
           "$ref": "#/definitions/MetaDocument",
+          "description": "Meta information about the document content.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "Meta",
@@ -134,6 +135,7 @@
         },
         "features": {
           "$ref": "#/definitions/MetaFeatures",
+          "description": "Feature dimensions that this CSN document fulfills.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "Meta",
@@ -387,6 +389,7 @@
         },
         "elements": {
           "$ref": "#/definitions/ElementDefinitions",
+          "description": "Dictionary of the elements of the entity.\nThe dictionary key is the element `name`, the value the element itself.\n\nMUST have at least one element.",
           "x-context": [
             "./spec/v1/CSN-Interop-Effective.schema.yaml",
             "EntityDefinition",
@@ -7467,7 +7470,8 @@
             "title": "Element Reference",
             "ref": "#/definitions/ElementReference"
           },
-          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`."
+          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`.",
+          "$ref": "#/definitions/ElementReference"
         },
         "distinctValues": {
           "type": "boolean",

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -5812,7 +5812,7 @@
           "description": "Additional bindings for filtering the value help result list."
         },
         "association": {
-          "description": "Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.\nMutually exclusive to the usage of `valueHelpDefinition.entity`."
+          "$ref": "#/definitions/ElementReference"
         },
         "distinctValues": {
           "type": "boolean",

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -6259,7 +6259,6 @@
       "description": "Entity is the root of a compositional hierarchy."
     },
     "@ObjectModel.representativeKey": {
-      "description": "In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)",
       "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.semanticKey": {
@@ -6321,7 +6320,6 @@
       }
     },
     "@ObjectModel.foreignKey.association": {
-      "description": "The element is of type `cds.Association` which points to the list of values. \n\nUse only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.",
       "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.text.element": {
@@ -6335,7 +6333,6 @@
       ]
     },
     "@ObjectModel.text.association": {
-      "description": "The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element",
       "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.SupportedCapabilities_EnumValue": {
@@ -6388,7 +6385,6 @@
       "description": "The entity represents an ODM Entity with this official name."
     },
     "@ODM.oid": {
-      "description": "The annotation references the element which contains the oid.",
       "$ref": "#/definitions/ElementReference"
     },
     "@ODM.oidReference.entityName": {
@@ -6483,7 +6479,6 @@
       "description": "The property contains a currency code."
     },
     "@Semantics.amount.currencyCode": {
-      "description": "The element contains an amount. The annotation points to an element containing the currency code.",
       "$ref": "#/definitions/ElementReference"
     },
     "@Semantics.unitOfMeasure": {
@@ -6492,7 +6487,6 @@
       "description": "The property contains a unit of measure."
     },
     "@Semantics.quantity.unitOfMeasure": {
-      "description": "The element contains a quantity.\nThe annotation points to an element containing the unit of measure.",
       "$ref": "#/definitions/ElementReference"
     },
     "@Semantics.calendar.dayOfMonth": {

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json",
+  "$id": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#",
   "title": "CSN Interop Root",
   "description": "Root of the CSN Interop Effective JSON document.\n\nSee [Primer: Root Level Structure](../primer.md#root-level-structure).",
   "definitions": {
@@ -3078,7 +3078,6 @@
           "description": "The (fully qualified) target entity name."
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject"
         },
         "on": {
@@ -3372,7 +3371,6 @@
           "description": "The (fully qualified) target entity name."
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject"
         },
         "on": {
@@ -5277,7 +5275,6 @@
           "description": "The (fully qualified) target entity name."
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject"
         },
         "on": {
@@ -5440,7 +5437,6 @@
           "description": "The (fully qualified) target entity name."
         },
         "cardinality": {
-          "type": "object",
           "$ref": "#/definitions/CardinalityObject"
         },
         "on": {
@@ -6662,6 +6658,7 @@
     },
     "definitions": {
       "$ref": "#/definitions/Definitions",
+      "$ref-type": "composition",
       "description": "Dictionary of CSN modeling artifacts.\n"
     },
     "i18n": {

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -4125,7 +4125,7 @@
     },
     "ElementReference": {
       "title": "Element Reference",
-      "description": "Element reference denotes a reference to an element.\n\nIt is RECOMMENDED to use the ElementReferenceObject notation.\n\nSee [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).",
+      "description": "Element reference to an element within the current entity.\n\nIt is RECOMMENDED to use the [ElementReferenceObject](#element-reference-object) notation.\n\nSee [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).",
       "oneOf": [
         {
           "$ref": "#/definitions/ElementReferenceString"
@@ -4138,12 +4138,12 @@
     "ElementReferenceString": {
       "title": "Element Reference String",
       "type": "string",
-      "description": "Element reference denotes a reference to an element, i.e. a member of the elements object of an entity in the following format:\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": \"<element name>\"\n```"
+      "description": "Element reference to an element within the current entity, using string notation.\n\nThe referenced element MUST exist locally in the same entity.\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": \"<element name>\"\n```"
     },
     "ElementReferenceObject": {
       "title": "Element Reference Object",
       "type": "object",
-      "description": "Element reference denotes a reference to an element, i.e. a member fo the elements object of an entity in the following format:\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": {\"=\": \"<element name>\"}\n```",
+      "description": "Element reference to an element within the current entity, using RECOMMENDED object notation.\n\nThe referenced element MUST exist locally in the same entity.\n\n```js\n\"<definition name>\": {\n  \"<annotation key of type ElementReference>\": {\"=\": \"<element name>\"}\n```",
       "properties": {
         "=": {
           "type": "string",

--- a/src/spec-v1/csn-interop-effective.schema.json
+++ b/src/spec-v1/csn-interop-effective.schema.json
@@ -6624,7 +6624,7 @@
       "description": "Link to JSON Schema for this CSN Interop Effective document.\nAdding this helps with automatic validation and code intelligence in some editors / IDEs.\n\nSee https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema\n",
       "anyOf": [
         {
-          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json"
+          "const": "https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#"
         },
         {
           "type": "string",
@@ -6658,7 +6658,6 @@
     },
     "definitions": {
       "$ref": "#/definitions/Definitions",
-      "$ref-type": "composition",
       "description": "Dictionary of CSN modeling artifacts.\n"
     },
     "i18n": {

--- a/src/spec-v1/objectmodel.annotated.schema.json
+++ b/src/spec-v1/objectmodel.annotated.schema.json
@@ -21,6 +21,7 @@
       ]
     },
     "@ObjectModel.representativeKey": {
+      "description": "In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)",
       "x-extension-targets": [
         "Entity",
         "Service"
@@ -131,6 +132,7 @@
       ]
     },
     "@ObjectModel.foreignKey.association": {
+      "description": "The element is of type `cds.Association` which points to the list of values. \n\nUse only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.",
       "x-extension-targets": [
         "Type"
       ],
@@ -169,6 +171,7 @@
       ]
     },
     "@ObjectModel.text.association": {
+      "description": "The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element",
       "x-extension-targets": [
         "Type"
       ],

--- a/src/spec-v1/objectmodel.annotated.schema.json
+++ b/src/spec-v1/objectmodel.annotated.schema.json
@@ -21,7 +21,6 @@
       ]
     },
     "@ObjectModel.representativeKey": {
-      "description": "In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)",
       "x-extension-targets": [
         "Entity",
         "Service"
@@ -34,7 +33,8 @@
       "x-context": [
         "./spec/annotations/object-model.yaml",
         "@ObjectModel.representativeKey"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.semanticKey": {
       "type": "array",
@@ -131,7 +131,6 @@
       ]
     },
     "@ObjectModel.foreignKey.association": {
-      "description": "The element is of type `cds.Association` which points to the list of values. \n\nUse only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.",
       "x-extension-targets": [
         "Type"
       ],
@@ -143,7 +142,8 @@
       "x-context": [
         "./spec/annotations/object-model.yaml",
         "@ObjectModel.foreignKey.association"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.text.element": {
       "type": "array",
@@ -169,7 +169,6 @@
       ]
     },
     "@ObjectModel.text.association": {
-      "description": "The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element",
       "x-extension-targets": [
         "Type"
       ],
@@ -181,7 +180,8 @@
       "x-context": [
         "./spec/annotations/object-model.yaml",
         "@ObjectModel.text.association"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@ObjectModel.SupportedCapabilities_EnumValue": {
       "title": "Supported Capabilities Enum Value",

--- a/src/spec-v1/odm.annotated.schema.json
+++ b/src/spec-v1/odm.annotated.schema.json
@@ -20,7 +20,6 @@
       ]
     },
     "@ODM.oid": {
-      "description": "The annotation references the element which contains the oid.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -32,7 +31,8 @@
       "x-context": [
         "./spec/annotations/odm.yaml",
         "@ODM.oid"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@ODM.oidReference.entityName": {
       "type": "string",

--- a/src/spec-v1/odm.annotated.schema.json
+++ b/src/spec-v1/odm.annotated.schema.json
@@ -20,6 +20,7 @@
       ]
     },
     "@ODM.oid": {
+      "description": "The annotation references the element which contains the oid.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"

--- a/src/spec-v1/semantics.annotated.schema.json
+++ b/src/spec-v1/semantics.annotated.schema.json
@@ -21,7 +21,6 @@
       ]
     },
     "@Semantics.amount.currencyCode": {
-      "description": "The element contains an amount. The annotation points to an element containing the currency code.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -33,7 +32,8 @@
       "x-context": [
         "./spec/annotations/semantics.yaml",
         "@Semantics.amount.currencyCode"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@Semantics.unitOfMeasure": {
       "type": "boolean",
@@ -49,7 +49,6 @@
       ]
     },
     "@Semantics.quantity.unitOfMeasure": {
-      "description": "The element contains a quantity.\nThe annotation points to an element containing the unit of measure.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -61,7 +60,8 @@
       "x-context": [
         "./spec/annotations/semantics.yaml",
         "@Semantics.quantity.unitOfMeasure"
-      ]
+      ],
+      "$ref": "#/definitions/ElementReference"
     },
     "@Semantics.calendar.dayOfMonth": {
       "type": "boolean",

--- a/src/spec-v1/semantics.annotated.schema.json
+++ b/src/spec-v1/semantics.annotated.schema.json
@@ -21,6 +21,7 @@
       ]
     },
     "@Semantics.amount.currencyCode": {
+      "description": "The element contains an amount. The annotation points to an element containing the currency code.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"
@@ -49,6 +50,7 @@
       ]
     },
     "@Semantics.quantity.unitOfMeasure": {
+      "description": "The element contains a quantity.\nThe annotation points to an element containing the unit of measure.",
       "x-ref-to-doc": {
         "title": "Element Reference",
         "ref": "#/definitions/ElementReference"

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -48,6 +48,25 @@ export type CdsType =
   | AssociationType
   | CompositionType;
 /**
+ * Element reference to an element within the current entity.
+ *
+ * It is RECOMMENDED to use the [ElementReferenceObject](#element-reference-object) notation.
+ *
+ * See [Primer: Literals for Enum and ElementRef values](../primer.md#literals-for-enum-and-elementref-values).
+ */
+export type ElementReference = ElementReferenceString | ElementReferenceObject;
+/**
+ * Element reference to an element within the current entity, using string notation.
+ *
+ * The referenced element MUST exist locally in the same entity.
+ *
+ * ```js
+ * "<definition name>": {
+ *   "<annotation key of type ElementReference>": "<element name>"
+ * ```
+ */
+export type ElementReferenceString = string;
+/**
  * The property defines how value helps for this element shall be constructed.
  *
  * It allows to associate a (set of) View/Entity that provides the "Value Help" for the annotated field or parameter.
@@ -84,18 +103,7 @@ export type ObjectModel = unknown[];
  *
  * Use only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.
  */
-export type ElementReference = ElementReferenceString | ElementReferenceObject;
-/**
- * Element reference to an element within the current entity, using string notation.
- *
- * The referenced element MUST exist locally in the same entity.
- *
- * ```js
- * "<definition name>": {
- *   "<annotation key of type ElementReference>": "<element name>"
- * ```
- */
-export type ElementReferenceString = string;
+export type ElementReference1 = ElementReferenceString | ElementReferenceObject;
 /**
  * The property contains element(s) containing a text for the annotated (id)element
  */
@@ -103,7 +111,7 @@ export type ObjectModelText = unknown[];
 /**
  * The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element
  */
-export type ElementReference1 = ElementReferenceString | ElementReferenceObject;
+export type ElementReference2 = ElementReferenceString | ElementReferenceObject;
 /**
  * The property contains an OID for the ODM Entity with this official name
  */
@@ -140,7 +148,7 @@ export type SemanticsCurrencyCode = true;
 /**
  * The element contains an amount. The annotation points to an element containing the currency code.
  */
-export type ElementReference2 = ElementReferenceString | ElementReferenceObject;
+export type ElementReference3 = ElementReferenceString | ElementReferenceObject;
 /**
  * The property contains a unit of measure.
  */
@@ -149,7 +157,7 @@ export type SemanticsUnitOfMeasure = true;
  * The element contains a quantity.
  * The annotation points to an element containing the unit of measure.
  */
-export type ElementReference3 = ElementReferenceString | ElementReferenceObject;
+export type ElementReference4 = ElementReferenceString | ElementReferenceObject;
 export type SemanticsCalendarDayOfMonth = true;
 export type SemanticsCalendarDayOfYear = true;
 export type SemanticsCalendarWeek = true;
@@ -257,7 +265,7 @@ export type ObjectModelCompositionRoot = boolean;
 /**
  * In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)
  */
-export type ElementReference4 = ElementReferenceString | ElementReferenceObject;
+export type ElementReference5 = ElementReferenceString | ElementReferenceObject;
 /**
  * The property declares the supported usage type for this entity in the context of consuming data models.
  */
@@ -269,7 +277,7 @@ export type ODMEntityName = string;
 /**
  * The annotation references the element which contains the oid.
  */
-export type ElementReference5 = ElementReferenceString | ElementReferenceObject;
+export type ElementReference6 = ElementReferenceString | ElementReferenceObject;
 export type PersonalDataEntitySemantics = "DataSubject" | "DataSubjectDetails" | "Other";
 export type PersonalDataEntitySemantics1 = string;
 /**
@@ -621,11 +629,11 @@ export interface EntityDefinition {
   "@EntityRelationship.temporalReferences"?: EntityRelationship4;
   "@EntityRelationship.referencesWithConstantIds"?: EntityRelationship5;
   "@ObjectModel.compositionRoot"?: ObjectModelCompositionRoot;
-  "@ObjectModel.representativeKey"?: ElementReference4;
+  "@ObjectModel.representativeKey"?: ElementReference5;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   "@ODM.entityName"?: ODMEntityName;
-  "@ODM.oid"?: ElementReference5;
+  "@ODM.oid"?: ElementReference6;
   /**
    * Primary meaning of the entities in the annotated entity set. Entities annotated with @PersonalData.entitySemantics are synonymous to @PersonalData.isPotentiallyPersonal.
    */
@@ -703,9 +711,9 @@ export interface BooleanType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -714,9 +722,9 @@ export interface BooleanType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -800,13 +808,7 @@ export interface ConsumptionValueHelpDefinition {
    * Additional bindings for filtering the value help result list.
    */
   additionalBinding?: AdditionalBinding[];
-  /**
-   * Reference to the modelled association (in local entity) for which the target view represents the value help providing view or entity for the annotated local field. The on-condition of the association may only contain bindings of the source and target fields that use an equal operator. All these bindings are automatically considered by the value help for both filter and result mappings.
-   * Mutually exclusive to the usage of `valueHelpDefinition.entity`.
-   */
-  association?: {
-    [k: string]: unknown | undefined;
-  };
+  association?: ElementReference;
   /**
    * Specifies whether the value help result list shall only contain distinct values for the annotated field or parameter.
    * If set to true all mappings will be used for filtering, but only the value for the field/parameter which the value help was requested for will be returned by the value help.
@@ -854,18 +856,6 @@ export interface ConsumptionConsumptionValueHelpDefinitionAdditionalBinding {
   "#": "FILTER" | "RESULT" | "FILTER_AND_RESULT";
 }
 /**
- * Defines a reference to another Entity Type based on a single ID.
- */
-export interface ReferenceTarget {
-  /**
-   * Optional name to describe the semantics of the reference.
-   */
-  name?: string;
-  referencedEntityType: EntityTypeID;
-  referencedPropertyType: PropertyTypeID;
-  [k: string]: unknown | undefined;
-}
-/**
  * Element reference to an element within the current entity, using RECOMMENDED object notation.
  *
  * The referenced element MUST exist locally in the same entity.
@@ -880,6 +870,18 @@ export interface ElementReferenceObject {
    * This is the references elements name.
    */
   "=": string;
+}
+/**
+ * Defines a reference to another Entity Type based on a single ID.
+ */
+export interface ReferenceTarget {
+  /**
+   * Optional name to describe the semantics of the reference.
+   */
+  name?: string;
+  referencedEntityType: EntityTypeID;
+  referencedPropertyType: PropertyTypeID;
+  [k: string]: unknown | undefined;
 }
 /**
  * An element of type `cds.String`.
@@ -922,9 +924,9 @@ export interface StringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -933,9 +935,9 @@ export interface StringType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1065,9 +1067,9 @@ export interface LargeStringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1076,9 +1078,9 @@ export interface LargeStringType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1162,9 +1164,9 @@ export interface IntegerType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1173,9 +1175,9 @@ export interface IntegerType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1265,9 +1267,9 @@ export interface Integer64Type {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1276,9 +1278,9 @@ export interface Integer64Type {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1368,9 +1370,9 @@ export interface DecimalType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1379,9 +1381,9 @@ export interface DecimalType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1466,9 +1468,9 @@ export interface DoubleType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1477,9 +1479,9 @@ export interface DoubleType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1563,9 +1565,9 @@ export interface DateType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1574,9 +1576,9 @@ export interface DateType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1660,9 +1662,9 @@ export interface TimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1671,9 +1673,9 @@ export interface TimeType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1757,9 +1759,9 @@ export interface DateTimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1768,9 +1770,9 @@ export interface DateTimeType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1854,9 +1856,9 @@ export interface TimestampType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1865,9 +1867,9 @@ export interface TimestampType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1950,9 +1952,9 @@ export interface UUIDType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1961,9 +1963,9 @@ export interface UUIDType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2060,9 +2062,9 @@ export interface AssociationType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2071,9 +2073,9 @@ export interface AssociationType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2218,9 +2220,9 @@ export interface CompositionType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2229,9 +2231,9 @@ export interface CompositionType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2376,9 +2378,9 @@ export interface CustomType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference;
+  "@ObjectModel.foreignKey.association"?: ElementReference1;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference1;
+  "@ObjectModel.text.association"?: ElementReference2;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2387,9 +2389,9 @@ export interface CustomType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference2;
+  "@Semantics.amount.currencyCode"?: ElementReference3;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference3;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2669,7 +2671,7 @@ export interface ServiceDefinition {
   doc?: string;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.quickInfo"?: EndUserTextQuickInfo;
-  "@ObjectModel.representativeKey"?: ElementReference4;
+  "@ObjectModel.representativeKey"?: ElementReference5;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   /**

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -86,7 +86,10 @@ export type ObjectModel = unknown[];
  */
 export type ElementReference = ElementReferenceString | ElementReferenceObject;
 /**
- * Element reference denotes a reference to an element, i.e. a member of the elements object of an entity in the following format:
+ * Element reference to an element within the current entity, using string notation.
+ *
+ * The referenced element MUST exist locally in the same entity.
+ *
  * ```js
  * "<definition name>": {
  *   "<annotation key of type ElementReference>": "<element name>"
@@ -863,7 +866,9 @@ export interface ReferenceTarget {
   [k: string]: unknown | undefined;
 }
 /**
- * Element reference denotes a reference to an element, i.e. a member fo the elements object of an entity in the following format:
+ * Element reference to an element within the current entity, using RECOMMENDED object notation.
+ *
+ * The referenced element MUST exist locally in the same entity.
  *
  * ```js
  * "<definition name>": {

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -2167,7 +2167,7 @@ export interface CompositionType {
    * The (fully qualified) target entity name.
    */
   target: string;
-  cardinality: CardinalityObject1;
+  cardinality: CardinalityObject;
   /**
    * The property `on` holds a sequence of operators and operands to describe the join condition.
    *
@@ -2253,31 +2253,6 @@ export interface CompositionType {
    * MAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.
    */
   [k: PrivatePropertyKey|AnnotationPropertyKey]: unknown;
-}
-/**
- * The cardinality indicates the number of instances of one entity that can or must be associated with each instance of another entity.
- *
- * SHOULD provide `min` and `max` values explicitly.
- */
-export interface CardinalityObject1 {
-  /**
-   * Set to `1` to give a hint to database optimizers, that the relationship is "one to".
-   *
-   * If `src` is not set then it is unknown and "many to" MAY be assumed.
-   */
-  src?: number;
-  /**
-   * Specifies the targets minimum cardinality.
-   */
-  min?: number;
-  /**
-   * Specifies the targets maximum cardinality.
-   *
-   * MUST be one of:
-   * - positive Integer (1,2,...)
-   * - `*` as String
-   */
-  max?: number | string;
 }
 /**
  * An Element can be of a Custom Type (aka Derived Type) instead of a standard [CDS type](#cds-type).
@@ -3275,7 +3250,7 @@ export interface AssociationTypeDefinition {
    * The (fully qualified) target entity name.
    */
   target: string;
-  cardinality: CardinalityObject2;
+  cardinality: CardinalityObject;
   /**
    * The property `on` holds a sequence of operators and operands to describe the join condition.
    *
@@ -3312,31 +3287,6 @@ export interface AssociationTypeDefinition {
    * MAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.
    */
   [k: PrivatePropertyKey|AnnotationPropertyKey]: unknown;
-}
-/**
- * The cardinality indicates the number of instances of one entity that can or must be associated with each instance of another entity.
- *
- * SHOULD provide `min` and `max` values explicitly.
- */
-export interface CardinalityObject2 {
-  /**
-   * Set to `1` to give a hint to database optimizers, that the relationship is "one to".
-   *
-   * If `src` is not set then it is unknown and "many to" MAY be assumed.
-   */
-  src?: number;
-  /**
-   * Specifies the targets minimum cardinality.
-   */
-  min?: number;
-  /**
-   * Specifies the targets maximum cardinality.
-   *
-   * MUST be one of:
-   * - positive Integer (1,2,...)
-   * - `*` as String
-   */
-  max?: number | string;
 }
 /**
  * A type definition of type `cds.Composition`.
@@ -3362,7 +3312,7 @@ export interface CompositionTypeDefinition {
    * The (fully qualified) target entity name.
    */
   target: string;
-  cardinality: CardinalityObject3;
+  cardinality: CardinalityObject;
   /**
    * The property `on` holds a sequence of operators and operands to describe the join condition.
    *
@@ -3399,31 +3349,6 @@ export interface CompositionTypeDefinition {
    * MAY be ignored by the consumers, as they have no cross-aligned, standardized semantics.
    */
   [k: PrivatePropertyKey|AnnotationPropertyKey]: unknown;
-}
-/**
- * The cardinality indicates the number of instances of one entity that can or must be associated with each instance of another entity.
- *
- * SHOULD provide `min` and `max` values explicitly.
- */
-export interface CardinalityObject3 {
-  /**
-   * Set to `1` to give a hint to database optimizers, that the relationship is "one to".
-   *
-   * If `src` is not set then it is unknown and "many to" MAY be assumed.
-   */
-  src?: number;
-  /**
-   * Specifies the targets minimum cardinality.
-   */
-  min?: number;
-  /**
-   * Specifies the targets maximum cardinality.
-   *
-   * MUST be one of:
-   * - positive Integer (1,2,...)
-   * - `*` as String
-   */
-  max?: number | string;
 }
 /**
  * Dictionary of translated texts.

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -99,19 +99,9 @@ export type EntityRelationship = ReferenceTarget[];
  */
 export type ObjectModel = unknown[];
 /**
- * The element is of type `cds.Association` which points to the list of values.
- *
- * Use only for service internal associations. For cross service associations, use the [@EntityRelationship Vocabulary](./entity-relationship) instead.
- */
-export type ElementReference1 = ElementReferenceString | ElementReferenceObject;
-/**
  * The property contains element(s) containing a text for the annotated (id)element
  */
 export type ObjectModelText = unknown[];
-/**
- * The element is of type cds.association, which points to an entity containing (language-dependent) texts for the annotated (id) element
- */
-export type ElementReference2 = ElementReferenceString | ElementReferenceObject;
 /**
  * The property contains an OID for the ODM Entity with this official name
  */
@@ -146,18 +136,9 @@ export type PersonalDataIsPotentiallySensitive = boolean;
  */
 export type SemanticsCurrencyCode = true;
 /**
- * The element contains an amount. The annotation points to an element containing the currency code.
- */
-export type ElementReference3 = ElementReferenceString | ElementReferenceObject;
-/**
  * The property contains a unit of measure.
  */
 export type SemanticsUnitOfMeasure = true;
-/**
- * The element contains a quantity.
- * The annotation points to an element containing the unit of measure.
- */
-export type ElementReference4 = ElementReferenceString | ElementReferenceObject;
 export type SemanticsCalendarDayOfMonth = true;
 export type SemanticsCalendarDayOfYear = true;
 export type SemanticsCalendarWeek = true;
@@ -263,10 +244,6 @@ export type EntityRelationship5 = ReferenceWithConstantID[];
  */
 export type ObjectModelCompositionRoot = boolean;
 /**
- * In case of multiple key elements: key element which represents the entity (in the sense that the entity itself is the list of values for this key element)
- */
-export type ElementReference5 = ElementReferenceString | ElementReferenceObject;
-/**
  * The property declares the supported usage type for this entity in the context of consuming data models.
  */
 export type ObjectModel2 = SupportedCapabilitiesEnumValue[];
@@ -274,10 +251,6 @@ export type ObjectModel2 = SupportedCapabilitiesEnumValue[];
  * The entity represents an ODM Entity with this official name.
  */
 export type ODMEntityName = string;
-/**
- * The annotation references the element which contains the oid.
- */
-export type ElementReference6 = ElementReferenceString | ElementReferenceObject;
 export type PersonalDataEntitySemantics = "DataSubject" | "DataSubjectDetails" | "Other";
 export type PersonalDataEntitySemantics1 = string;
 /**
@@ -629,11 +602,11 @@ export interface EntityDefinition {
   "@EntityRelationship.temporalReferences"?: EntityRelationship4;
   "@EntityRelationship.referencesWithConstantIds"?: EntityRelationship5;
   "@ObjectModel.compositionRoot"?: ObjectModelCompositionRoot;
-  "@ObjectModel.representativeKey"?: ElementReference5;
+  "@ObjectModel.representativeKey"?: ElementReference;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   "@ODM.entityName"?: ODMEntityName;
-  "@ODM.oid"?: ElementReference6;
+  "@ODM.oid"?: ElementReference;
   /**
    * Primary meaning of the entities in the annotated entity set. Entities annotated with @PersonalData.entitySemantics are synonymous to @PersonalData.isPotentiallyPersonal.
    */
@@ -711,9 +684,9 @@ export interface BooleanType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -722,9 +695,9 @@ export interface BooleanType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -924,9 +897,9 @@ export interface StringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -935,9 +908,9 @@ export interface StringType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1067,9 +1040,9 @@ export interface LargeStringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1078,9 +1051,9 @@ export interface LargeStringType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1164,9 +1137,9 @@ export interface IntegerType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1175,9 +1148,9 @@ export interface IntegerType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1267,9 +1240,9 @@ export interface Integer64Type {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1278,9 +1251,9 @@ export interface Integer64Type {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1370,9 +1343,9 @@ export interface DecimalType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1381,9 +1354,9 @@ export interface DecimalType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1468,9 +1441,9 @@ export interface DoubleType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1479,9 +1452,9 @@ export interface DoubleType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1565,9 +1538,9 @@ export interface DateType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1576,9 +1549,9 @@ export interface DateType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1662,9 +1635,9 @@ export interface TimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1673,9 +1646,9 @@ export interface TimeType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1759,9 +1732,9 @@ export interface DateTimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1770,9 +1743,9 @@ export interface DateTimeType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1856,9 +1829,9 @@ export interface TimestampType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1867,9 +1840,9 @@ export interface TimestampType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -1952,9 +1925,9 @@ export interface UUIDType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -1963,9 +1936,9 @@ export interface UUIDType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2062,9 +2035,9 @@ export interface AssociationType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2073,9 +2046,9 @@ export interface AssociationType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2220,9 +2193,9 @@ export interface CompositionType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2231,9 +2204,9 @@ export interface CompositionType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2378,9 +2351,9 @@ export interface CustomType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
-  "@ObjectModel.foreignKey.association"?: ElementReference1;
+  "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
-  "@ObjectModel.text.association"?: ElementReference2;
+  "@ObjectModel.text.association"?: ElementReference;
   "@ODM.oidReference.entityName"?: ODMOidReferenceEntityName;
   /**
    * Primary meaning of the personal data contained in the annotated property. Changes to values of annotated properties are tracked in the audit log. Use this annotation also on fields that are already marked as contact or address data. Properties annotated with fieldSemantics need not be additionally annotated with @PersonalData.isPotentiallyPersonal.
@@ -2389,9 +2362,9 @@ export interface CustomType {
   "@PersonalData.isPotentiallyPersonal"?: PersonalDataIsPotentiallyPersonal;
   "@PersonalData.isPotentiallySensitive"?: PersonalDataIsPotentiallySensitive;
   "@Semantics.currencyCode"?: SemanticsCurrencyCode;
-  "@Semantics.amount.currencyCode"?: ElementReference3;
+  "@Semantics.amount.currencyCode"?: ElementReference;
   "@Semantics.unitOfMeasure"?: SemanticsUnitOfMeasure;
-  "@Semantics.quantity.unitOfMeasure"?: ElementReference4;
+  "@Semantics.quantity.unitOfMeasure"?: ElementReference;
   "@Semantics.calendar.dayOfMonth"?: SemanticsCalendarDayOfMonth;
   "@Semantics.calendar.dayOfYear"?: SemanticsCalendarDayOfYear;
   "@Semantics.calendar.week"?: SemanticsCalendarWeek;
@@ -2671,7 +2644,7 @@ export interface ServiceDefinition {
   doc?: string;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.quickInfo"?: EndUserTextQuickInfo;
-  "@ObjectModel.representativeKey"?: ElementReference5;
+  "@ObjectModel.representativeKey"?: ElementReference;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   /**

--- a/src/types/v1/CSN-Interop-Effective.ts
+++ b/src/types/v1/CSN-Interop-Effective.ts
@@ -302,7 +302,7 @@ export interface CSNInteropRoot {
    * See https://tour.json-schema.org/content/06-Combining-Subschemas/02-id-and-schema
    *
    */
-  $schema?: ("https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json" | string) &
+  $schema?: ("https://sap.github.io/csn-interop-specification/spec-v1/csn-interop-effective.schema.json#" | string) &
     string;
   /**
    * Optional URI for this document, that can acts as an ID or as location to retrieve the document.


### PR DESCRIPTION
Bug: Where we use `x-ref-to-doc`, the final generated JSON Schema does not contain a `$ref` link anymore. It's rendered correctly in the documentation, but the JSON Schema is missing the reference. 

By fixing this, we also improve the generated TypeScript interfaces:

![image](https://github.com/user-attachments/assets/a37c0e03-3cb1-4717-ae61-e86663c8a197)
