### PR TITLE
fix(spec-toolkit): refactor spec toolkit typescript types auto-generation

### DIFF
--- a/spec-toolkit/src/generate.ts
+++ b/spec-toolkit/src/generate.ts
@@ -28,7 +28,7 @@ export async function generate(configData: ConfigFile): Promise<void> {
   log.info("--------------------------------------------------------------------------");
   log.info("GENERATE AND MERGE SPEC EXTENSIONS");
   log.info("--------------------------------------------------------------------------");
-  const mergedSpecSchema = mergeSpecExtensions(configData);
+  mergeSpecExtensions(configData);
 
   log.info(" ");
   log.info("--------------------------------------------------------------------------");
@@ -40,7 +40,7 @@ export async function generate(configData: ConfigFile): Promise<void> {
   log.info("--------------------------------------------------------------------------");
   log.info("GENERATE TypeScript Definitions");
   log.info("--------------------------------------------------------------------------");
-  await generateTypeScriptDefinitions("CSN-Interop-Effective", mergedSpecSchema);
+  await generateTypeScriptDefinitions(configData);
 
   log.info(" ");
   log.info("==========================================================================");

--- a/spec-toolkit/src/generateInterfaceDocumentation.ts
+++ b/spec-toolkit/src/generateInterfaceDocumentation.ts
@@ -98,7 +98,7 @@ export function jsonSchemaToDocumentation(configData: ConfigFile): void {
 
     // Read extension target file if given
     let extensionTarget: SpecJsonSchemaRoot | undefined;
-    if (docConfig.type === "extension") {
+    if (docConfig.type === "specExtension") {
       const file = fs.readFileSync(docConfig.targetDocument).toString();
       extensionTarget = yaml.load(file) as SpecJsonSchemaRoot;
     }
@@ -117,7 +117,7 @@ export function jsonSchemaToDocumentation(configData: ConfigFile): void {
 
     text += "\n\n## Schema Definitions\n\n";
 
-    if (docConfig.type === "extension") {
+    if (docConfig.type === "specExtension") {
       text += `* This is an extension vocabulary for [${extensionTarget?.title}](${docConfig.targetLink}).\n`;
     } else if (jsonSchemaRoot.$ref) {
       const referencedSchema = getReferencedSchema(jsonSchemaRoot.$ref, jsonSchemaRoot, docConfig.title);
@@ -147,7 +147,7 @@ export function jsonSchemaToDocumentation(configData: ConfigFile): void {
     }
 
     // If extension: Create extension property overview table
-    if (docConfig.type === "extension") {
+    if (docConfig.type === "specExtension") {
       text += getExtensionOverviewTable(jsonSchemaRoot);
     }
 
@@ -183,7 +183,7 @@ export function jsonSchemaToDocumentation(configData: ConfigFile): void {
     fs.outputFileSync(docConfig.targetMarkdownFilePath, text);
     log.info(`Written: ${docConfig.targetMarkdownFilePath}`);
 
-    if (!jsonSchemaRoot.type && docConfig.type === "main") {
+    if (!jsonSchemaRoot.type && docConfig.type === "spec") {
       jsonSchemaRoot = ensureRootLevelSchema(jsonSchemaRoot);
     }
 
@@ -323,7 +323,7 @@ function getTypeColumnText(
     }
   }
   //in case it is a primitive type just return it
-  else if (jsonSchemaObject["x-ref-to-doc"] && specConfig.type === "extension") {
+  else if (jsonSchemaObject["x-ref-to-doc"] && specConfig.type === "specExtension") {
     return `[${jsonSchemaObject["x-ref-to-doc"].title}](${specConfig.targetLink}${getAnchorLinkFromTitle(jsonSchemaObject["x-ref-to-doc"].title)})`;
   }
   // if its referencing to an interface in another document, create a cross-page link:
@@ -831,7 +831,7 @@ function generatePrimitiveTypeDescription(
     text += `<strong className="introduced-version">Introduced in Version</strong>: ${jsonSchemaObject["x-introduced-in-version"]}<br/>\n`;
   }
 
-  if (jsonSchemaObject["x-ref-to-doc"] && specConfig.type === "extension") {
+  if (jsonSchemaObject["x-ref-to-doc"] && specConfig.type === "specExtension") {
     text += `**External Type**: [${jsonSchemaObject["x-ref-to-doc"].title}](${specConfig.targetLink}${getAnchorLinkFromTitle(jsonSchemaObject["x-ref-to-doc"].title)}) <br/>\n`;
   }
 
@@ -848,7 +848,7 @@ function generatePrimitiveTypeDescription(
         if (
           definition["x-extension-points"] &&
           definition["x-extension-points"].includes(extensionPoint) &&
-          specConfig.type === "extension"
+          specConfig.type === "specExtension"
         ) {
           text += `[${definitionName}](${specConfig.targetLink}${getAnchorLinkFromTitle(definition.title)}), `;
           found++;

--- a/spec-toolkit/src/generateInterfaceDocumentation.ts
+++ b/spec-toolkit/src/generateInterfaceDocumentation.ts
@@ -1328,6 +1328,22 @@ export function writeSpecJsonSchemaFiles(
 
     // write it as schema file that does not include all the x- extensions
     fs.outputFileSync(filePath, JSON.stringify(jsonSchema2, null, 2));
+
+    // temporary write it as schema file that includes all the x- extensions to filesystem
+    // needed for the typescript types generation and the file will be deleted afterwards
+    const xSchemaFileName = filePath.split(".json").join(".x.json");
+    fs.outputFileSync(
+      xSchemaFileName,
+      JSON.stringify(
+        {
+          description: "JSON Schema with custom (x-) annotations",
+          ...refConvertedJsonSchema,
+        },
+        null,
+        2,
+      ),
+    );
+    log.info(`Write to file system temporary file ${xSchemaFileName}`);
   } else {
     // write it as schema file that includes all the x- extensions
     fs.outputFileSync(

--- a/spec-toolkit/src/generateTypeScriptDefinitions.ts
+++ b/spec-toolkit/src/generateTypeScriptDefinitions.ts
@@ -14,68 +14,71 @@ import fs from "fs-extra";
 import { compile as jsonSchemaToTypeScript } from "json-schema-to-typescript";
 import { log } from "./util/log.js";
 import yaml from "js-yaml";
+import { ConfigFile } from "./model/Config.js";
 
-export async function generateTypeScriptDefinitions(schemaName: string, schema?: SpecJsonSchemaRoot): Promise<string> {
-  if (!schema) {
-    schema = yaml.load(fs.readFileSync(`./spec/v1/${schemaName}.schema.yaml`).toString()) as SpecJsonSchemaRoot;
-  }
+export async function generateTypeScriptDefinitions(configData: ConfigFile): Promise<void> {
+  for (const docConfig of configData.docsConfig) {
+    // typescript types will be generated only for spec documents
+    // because specExtension documents are just fragments that will be merged into the bigger spec document
+    // it does not make sense to have typescript types generated out of fragment files
+    if (docConfig.type === "spec") {
+      const xSchemaFileName = docConfig.targetJsonSchemaFilePath.split(".json").join(".x.json");
+      let schema = yaml.load(fs.readFileSync(xSchemaFileName).toString()) as SpecJsonSchemaRoot;
 
-  schema = convertRefToDocToStandardRef(schema);
-  schema = convertOneOfEnum(schema);
-  schema = convertAnyOfEnum(schema);
-  schema = convertAllOfWithIfThenDiscriminatorToOneOf(schema);
+      schema = convertRefToDocToStandardRef(schema);
+      schema = convertOneOfEnum(schema);
+      schema = convertAnyOfEnum(schema);
+      schema = convertAllOfWithIfThenDiscriminatorToOneOf(schema);
 
-  // Schema cleaned up
-  schema = removeDescriptionsFromRefPointers(schema);
-  const allCustomPropertiesTypescriptTypes = schema["x-custom-typescript-types"];
-  schema = removeExtensionAttributes(schema);
-  schema = ensureRootLevelSchema(schema);
-  const convertedDocumentSchema = schema as JSONSchema4;
+      // Schema cleaned up
+      schema = removeDescriptionsFromRefPointers(schema);
+      const allCustomPropertiesTypescriptTypes = schema["x-custom-typescript-types"];
+      schema = removeExtensionAttributes(schema);
+      schema = ensureRootLevelSchema(schema);
+      const convertedDocumentSchema = schema as JSONSchema4;
 
-  let definitions = await jsonSchemaToTypeScript(convertedDocumentSchema, `${schemaName}`, {
-    unknownAny: true,
-    bannerComment: "// AUTO-GENERATED definition files. Do not modify directly.\n\n",
-    strictIndexSignatures: true,
-    declareExternallyReferenced: true,
-    inferStringEnumKeysFromValues: false,
-  });
+      let definitions = await jsonSchemaToTypeScript(convertedDocumentSchema, `${docConfig.id}`, {
+        unknownAny: true,
+        bannerComment: "// AUTO-GENERATED definition files. Do not modify directly.\n\n",
+        strictIndexSignatures: true,
+        declareExternallyReferenced: true,
+        inferStringEnumKeysFromValues: false,
+      });
 
-  // Clean up unnecessary "This interface was referenced..." mentions
-  definitions = definitions.replace(/ {3}\*\n {3}\* This interface was referenced by (.*)\n(.*)\n/gm, "");
+      // Clean up unnecessary "This interface was referenced..." mentions
+      definitions = definitions.replace(/ {3}\*\n {3}\* This interface was referenced by (.*)\n(.*)\n/gm, "");
 
-  // Add export of custom defined x-custom-typescript-types
-  if (allCustomPropertiesTypescriptTypes) {
-    for (const xPatternPropertiesTypescriptTypes of allCustomPropertiesTypescriptTypes) {
-      definitions +=
-        `\n export type ${xPatternPropertiesTypescriptTypes.typeName} = ` +
-        `${xPatternPropertiesTypescriptTypes.typeValue}` +
-        `;\n`;
+      // Add export of custom defined x-custom-typescript-types
+      if (allCustomPropertiesTypescriptTypes) {
+        for (const xPatternPropertiesTypescriptTypes of allCustomPropertiesTypescriptTypes) {
+          definitions +=
+            `\n export type ${xPatternPropertiesTypescriptTypes.typeName} = ` +
+            `${xPatternPropertiesTypescriptTypes.typeValue}` +
+            `;\n`;
+        }
+      }
+
+      // Post processing for all tsType "// replaceKeyType_" markings
+      const allPostProcessingReplacements: { oldValue: string; newValue: string }[] = [];
+      const allPostProcessingReplacementMatches = [...definitions.matchAll(/.*replaceKeyType_{(.*)}/gm)];
+      for (const match of allPostProcessingReplacementMatches) {
+        const replacementNewValue = match[0].replace("string", match[1]).split(";")[0] + ";";
+        const indexStart = match.index;
+        const indexEnd = match.index + match[0].length;
+        allPostProcessingReplacements.push({
+          oldValue: definitions.substring(indexStart, indexEnd),
+          newValue: replacementNewValue,
+        });
+      }
+      for (const replacement of allPostProcessingReplacements) {
+        definitions = definitions.replace(replacement.oldValue, replacement.newValue);
+      }
+
+      fs.unlinkSync(xSchemaFileName);
+      log.info(`Cleanup temporary file ${xSchemaFileName}`);
+
+      await fs.outputFile(`${process.cwd()}/${docConfig.targetTypescriptTypesFilePath}`, definitions);
+      log.info(`Result: ./${docConfig.targetTypescriptTypesFilePath}`);
     }
   }
-
-  // Post processing for all tsType "// replaceKeyType_" markings
-  const allPostProcessingReplacements: { oldValue: string; newValue: string }[] = [];
-  const allPostProcessingReplacementMatches = [...definitions.matchAll(/.*replaceKeyType_{(.*)}/gm)];
-  for (const match of allPostProcessingReplacementMatches) {
-    const replacementNewValue = match[0].replace("string", match[1]).split(";")[0] + ";";
-    const indexStart = match.index;
-    const indexEnd = match.index + match[0].length;
-    allPostProcessingReplacements.push({
-      oldValue: definitions.substring(indexStart, indexEnd),
-      newValue: replacementNewValue,
-    });
-  }
-  for (const replacement of allPostProcessingReplacements) {
-    definitions = definitions.replace(replacement.oldValue, replacement.newValue);
-  }
-
-  const filePath1 = `src/types/v1/${schemaName}.ts`;
-  await fs.outputFile(`${process.cwd()}/${filePath1}`, definitions);
-  log.info(`Result: ./${filePath1}`);
-  // const filePath3 = `src/spec-v1/interfaces/${schemaName}.ts`
-  // await fs.outputFile(`${process.cwd()}/${filePath3}`, definitions)
-  // const filePath2 = `src/spec-v1/interfaces/${schemaName}.ts.txt`
-  // await fs.outputFile(`${process.cwd()}/${filePath2}`, definitions)
-
-  return definitions;
 }

--- a/spec-toolkit/src/mergeSpecExtensions.ts
+++ b/spec-toolkit/src/mergeSpecExtensions.ts
@@ -7,7 +7,7 @@ import { writeSpecJsonSchemaFiles } from "./generateInterfaceDocumentation.js";
 import { ConfigFile } from "./model/Config.js";
 import path from "path";
 
-export function mergeSpecExtensions(configData: ConfigFile): SpecJsonSchemaRoot | undefined {
+export function mergeSpecExtensions(configData: ConfigFile): void {
   for (const docConfig1 of configData.docsConfig) {
     if (docConfig1.type === "spec") {
       const targetDocumentFilePath = docConfig1.targetJsonSchemaFilePath;
@@ -104,8 +104,6 @@ export function mergeSpecExtensions(configData: ConfigFile): SpecJsonSchemaRoot 
       writeSpecJsonSchemaFiles(targetDocumentFilePath, targetDocument, true);
 
       log.info(`Written: ${targetDocumentFilePath}`);
-
-      return targetDocument;
     }
   }
 }

--- a/spec-toolkit/src/mergeSpecExtensions.ts
+++ b/spec-toolkit/src/mergeSpecExtensions.ts
@@ -9,14 +9,14 @@ import path from "path";
 
 export function mergeSpecExtensions(configData: ConfigFile): SpecJsonSchemaRoot | undefined {
   for (const docConfig1 of configData.docsConfig) {
-    if (docConfig1.type === "main") {
+    if (docConfig1.type === "spec") {
       const targetDocumentFilePath = docConfig1.targetJsonSchemaFilePath;
       const jsonSchemaFile = fs.readFileSync(path.join(process.cwd(), targetDocumentFilePath)).toString();
       const targetDocument = yaml.load(jsonSchemaFile) as SpecJsonSchemaRoot;
 
       const specExtensions: string[] = [];
       for (const docConfig2 of configData.docsConfig) {
-        if (docConfig2.type === "extension" && docConfig2.targetDocument === docConfig1.sourceFilePath) {
+        if (docConfig2.type === "specExtension" && docConfig2.targetDocument === docConfig1.sourceFilePath) {
           specExtensions.push(docConfig2.sourceFilePath);
         }
       }

--- a/spec-toolkit/src/model/Config.ts
+++ b/spec-toolkit/src/model/Config.ts
@@ -10,11 +10,11 @@ export interface GeneralConfig {
   sortProperties: boolean;
 }
 
-export type SpecType = "main" | "extension";
+export type SpecType = "spec" | "specExtension";
 export type SpecConfig = MainSpecConfig | ExtensionSpecConfig;
 // Configuration Document Interface
 export interface MainSpecConfig {
-  type: "main";
+  type: "spec";
   id: string;
   title: string;
   sourceFilePath: string;
@@ -36,7 +36,7 @@ export interface MainSpecConfig {
   facts?: string[];
 }
 export interface ExtensionSpecConfig {
-  type: "extension";
+  type: "specExtension";
   id: string;
   title: string;
   sourceFilePath: string;

--- a/spec-toolkit/src/model/Config.ts
+++ b/spec-toolkit/src/model/Config.ts
@@ -22,6 +22,7 @@ export interface MainSpecConfig {
   sourceFileOutro?: string;
   targetMarkdownFilePath: string;
   targetJsonSchemaFilePath: string;
+  targetTypescriptTypesFilePath: string;
   targetFolder?: string;
   sideBarPosition: number;
   sideBarDescription: string;

--- a/src/genConfig.json
+++ b/src/genConfig.json
@@ -15,6 +15,7 @@
       "title": "Interface Documentation",
       "targetMarkdownFilePath": "docs/spec-v1/csn-interop-effective.md",
       "targetJsonSchemaFilePath": "src/spec-v1/csn-interop-effective.schema.json",
+      "targetTypescriptTypesFilePath": "src/types/v1/CSN-Interop-Effective.ts",
       "facts": []
     },
     {

--- a/src/genConfig.json
+++ b/src/genConfig.json
@@ -5,7 +5,7 @@
   },
   "docsConfig": [
     {
-      "type": "main",
+      "type": "spec",
       "id": "CSN-Interop-Effective",
       "sourceFilePath": "./spec/v1/CSN-Interop-Effective.schema.yaml",
       "sourceIntroductionFilePath": "./spec/v1/CSN-Interop-Effective.schema.md",
@@ -18,7 +18,7 @@
       "facts": []
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@Aggregation",
       "sourceFilePath": "./spec/annotations/aggregation.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/aggregation.md",
@@ -31,7 +31,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@AnalyticsDetails",
       "sourceFilePath": "./spec/annotations/analytics-details.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/analytics-details.md",
@@ -44,7 +44,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@Consumption",
       "sourceFilePath": "./spec/annotations/consumption.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/consumption.md",
@@ -57,7 +57,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@EndUserText",
       "title": "@EndUserText",
       "sourceFilePath": "./spec/annotations/enduser-text.yaml",
@@ -70,7 +70,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@EntityRelationship",
       "sourceFilePath": "./spec/annotations/entity-relationship.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/entity-relationship.md",
@@ -84,7 +84,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@ObjectModel",
       "sourceFilePath": "./spec/annotations/object-model.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/object-model.md",
@@ -97,7 +97,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@ODM",
       "sourceFilePath": "./spec/annotations/odm.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/odm.md",
@@ -110,7 +110,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@PersonalData",
       "sourceFilePath": "./spec/annotations/personal-data.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/personal-data.md",
@@ -123,7 +123,7 @@
       "targetLink": "../spec-v1/csn-interop-effective"
     },
     {
-      "type": "extension",
+      "type": "specExtension",
       "id": "@Semantics",
       "sourceFilePath": "./spec/annotations/semantics.yaml",
       "sourceIntroductionFilePath": "./spec/annotations/semantics.md",


### PR DESCRIPTION
Properly generate typescript types for each (main)spec defined in spec-toolkit config.