### PR TITLE
Remove beta label from 1.0 release name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: "Overview"
 
 # Core Schema Notation Interoperability Specification
 
-**STATUS**: v1.0 <span className="feature-status-beta">BETA</span>, stable release planned for 2025-02.
+**STATUS**: v1.0.
 
 ## Summary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: "Overview"
 
 # Core Schema Notation Interoperability Specification
 
-**STATUS**: v1.0.
+**VERSION**: v1.0
 
 ## Summary
 


### PR DESCRIPTION
Forgot this, should have been done with 1.0.0 release :)