### PR TITLE
Add ObjectModel.owner annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `@ObjectModel.owner` annotation to state ownership for parts of the CSN model where it differs from the main ownership.
+
 ## [1.0.3]
 
 ### Fixed

--- a/spec/v1/annotations/object-model.yaml
+++ b/spec/v1/annotations/object-model.yaml
@@ -31,6 +31,25 @@ definitions:
         title: Element Reference
         ref: "#/definitions/ElementReference"
 
+  "@ObjectModel.owner":
+    type: string
+    description: |-
+      State the owner of the CSN model part, where it differs from the main ownership.
+      This can happen with extensions, which can be created by customers, partners or by industry extensions.
+
+      The value MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1#namespaces).
+      If the annotation is not present, the owner is identical to the owner of the overall CSN model.
+
+      For extensions created by the customer / owner of the system instance, use the reserved `customer` namespace.
+    pattern: ^[a-z0-9]+(?:[.][a-z0-9]+)*$
+    x-extension-targets:
+      - "Entity"
+      - "Type"
+      - "Service"
+    examples:
+      - "customer"
+      - "somevendor.authority"
+
   "@ObjectModel.modelingPattern":
     type: object
     description: |-
@@ -121,7 +140,7 @@ definitions:
   "@ObjectModel.tenantWideUniqueName":
     type: string
     description: |-
-      Unique technical name of the entity within the tenant / isolation context it is deployed to. 
+      Unique technical name of the entity within the tenant / isolation context it is deployed to.
       This may be used as a hint for database table names and help to keep them short enough.
 
       Once chosen the technical name ID MUST be kept stable (immutable).
@@ -131,15 +150,15 @@ definitions:
   "@ObjectModel.usageType.sizeCategory":
     type: object
     description: |-
-      The size category enables the consumer to judge the possible result data set size. 
+      The size category enables the consumer to judge the possible result data set size.
       It is a pure estimation at design time while modeling the entity what the data set size would be at runtime.
-      It reflects the set of data which has to be searched through to compute for example a count(*) of the data. 
+      It reflects the set of data which has to be searched through to compute for example a count(*) of the data.
 
       The labels correspond to the following size categories (expected number of rows at production customers):
       - S: less than 1000
       - M: less than 100.000
       - L: less than 10.000.000
-      - XL: less than 100.000.000  
+      - XL: less than 100.000.000
       - XXL: more than 100.000.000
     properties:
       "#":

--- a/src/generated/spec-v1/schemas/csn-interop-effective.schema.json
+++ b/src/generated/spec-v1/schemas/csn-interop-effective.schema.json
@@ -374,6 +374,9 @@
         "@ObjectModel.representativeKey": {
           "$ref": "#/definitions/@ObjectModel.representativeKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.modelingPattern": {
           "$ref": "#/definitions/@ObjectModel.modelingPattern"
         },
@@ -789,6 +792,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -992,6 +998,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -1193,6 +1202,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -1392,6 +1404,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -1593,6 +1608,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -1809,6 +1827,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -2007,6 +2028,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -2209,6 +2233,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -2404,6 +2431,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -2601,6 +2631,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -2797,6 +2830,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -2989,6 +3025,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -3270,6 +3309,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -3574,6 +3616,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -3814,6 +3859,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -4333,6 +4381,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -4744,6 +4795,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -4949,6 +5003,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -5157,6 +5214,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -5348,6 +5408,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -5552,6 +5615,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -5766,6 +5832,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -5972,6 +6041,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -6166,6 +6238,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -6365,6 +6440,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -6556,6 +6634,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -6749,6 +6830,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -6937,6 +7021,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -7218,6 +7305,9 @@
         },
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
@@ -7527,6 +7617,9 @@
         "@ObjectModel.semanticKey": {
           "$ref": "#/definitions/@ObjectModel.semanticKey"
         },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
+        },
         "@ObjectModel.foreignKey.association": {
           "$ref": "#/definitions/@ObjectModel.foreignKey.association"
         },
@@ -7715,6 +7808,9 @@
         },
         "@ObjectModel.representativeKey": {
           "$ref": "#/definitions/@ObjectModel.representativeKey"
+        },
+        "@ObjectModel.owner": {
+          "$ref": "#/definitions/@ObjectModel.owner"
         },
         "@ObjectModel.modelingPattern": {
           "$ref": "#/definitions/@ObjectModel.modelingPattern"
@@ -8444,6 +8540,20 @@
       ],
       "items": {}
     },
+    "@ObjectModel.owner": {
+      "type": "string",
+      "description": "State the owner of the CSN model part, where it differs from the main ownership.\nThis can happen with extensions, which can be created by customers, partners or by industry extensions.\n\nThe value MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1#namespaces).\nIf the annotation is not present, the owner is identical to the owner of the overall CSN model.\n\nFor extensions created by the customer / owner of the system instance, use the reserved `customer` namespace.",
+      "pattern": "^[a-z0-9]+(?:[.][a-z0-9]+)*$",
+      "x-extension-targets": [
+        "Entity",
+        "Type",
+        "Service"
+      ],
+      "examples": [
+        "customer",
+        "somevendor.authority"
+      ]
+    },
     "@ObjectModel.modelingPattern": {
       "type": "object",
       "description": "The property declares the modeling pattern applied in this entity definition.",
@@ -8532,7 +8642,7 @@
     },
     "@ObjectModel.tenantWideUniqueName": {
       "type": "string",
-      "description": "Unique technical name of the entity within the tenant / isolation context it is deployed to. \nThis may be used as a hint for database table names and help to keep them short enough.\n\nOnce chosen the technical name ID MUST be kept stable (immutable).",
+      "description": "Unique technical name of the entity within the tenant / isolation context it is deployed to.\nThis may be used as a hint for database table names and help to keep them short enough.\n\nOnce chosen the technical name ID MUST be kept stable (immutable).",
       "maxLength": 120,
       "x-extension-targets": [
         "Entity"
@@ -8540,7 +8650,7 @@
     },
     "@ObjectModel.usageType.sizeCategory": {
       "type": "object",
-      "description": "The size category enables the consumer to judge the possible result data set size. \nIt is a pure estimation at design time while modeling the entity what the data set size would be at runtime.\nIt reflects the set of data which has to be searched through to compute for example a count(*) of the data. \n\nThe labels correspond to the following size categories (expected number of rows at production customers):\n- S: less than 1000\n- M: less than 100.000\n- L: less than 10.000.000\n- XL: less than 100.000.000  \n- XXL: more than 100.000.000",
+      "description": "The size category enables the consumer to judge the possible result data set size.\nIt is a pure estimation at design time while modeling the entity what the data set size would be at runtime.\nIt reflects the set of data which has to be searched through to compute for example a count(*) of the data.\n\nThe labels correspond to the following size categories (expected number of rows at production customers):\n- S: less than 1000\n- M: less than 100.000\n- L: less than 10.000.000\n- XL: less than 100.000.000\n- XXL: more than 100.000.000",
       "properties": {
         "#": {
           "type": "string",

--- a/src/generated/spec-v1/schemas/object-model.schema.json
+++ b/src/generated/spec-v1/schemas/object-model.schema.json
@@ -51,6 +51,25 @@
         "@ObjectModel.semanticKey"
       ]
     },
+    "@ObjectModel.owner": {
+      "type": "string",
+      "description": "State the owner of the CSN model part, where it differs from the main ownership.\nThis can happen with extensions, which can be created by customers, partners or by industry extensions.\n\nThe value MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1#namespaces).\nIf the annotation is not present, the owner is identical to the owner of the overall CSN model.\n\nFor extensions created by the customer / owner of the system instance, use the reserved `customer` namespace.",
+      "pattern": "^[a-z0-9]+(?:[.][a-z0-9]+)*$",
+      "x-extension-targets": [
+        "Entity",
+        "Type",
+        "Service"
+      ],
+      "examples": [
+        "customer",
+        "somevendor.authority"
+      ],
+      "title": "@ObjectModel.owner",
+      "x-context": [
+        "./spec/v1/annotations/object-model.yaml",
+        "@ObjectModel.owner"
+      ]
+    },
     "@ObjectModel.modelingPattern": {
       "type": "object",
       "description": "The property declares the modeling pattern applied in this entity definition.",
@@ -184,7 +203,7 @@
     },
     "@ObjectModel.tenantWideUniqueName": {
       "type": "string",
-      "description": "Unique technical name of the entity within the tenant / isolation context it is deployed to. \nThis may be used as a hint for database table names and help to keep them short enough.\n\nOnce chosen the technical name ID MUST be kept stable (immutable).",
+      "description": "Unique technical name of the entity within the tenant / isolation context it is deployed to.\nThis may be used as a hint for database table names and help to keep them short enough.\n\nOnce chosen the technical name ID MUST be kept stable (immutable).",
       "maxLength": 120,
       "x-extension-targets": [
         "Entity"
@@ -197,7 +216,7 @@
     },
     "@ObjectModel.usageType.sizeCategory": {
       "type": "object",
-      "description": "The size category enables the consumer to judge the possible result data set size. \nIt is a pure estimation at design time while modeling the entity what the data set size would be at runtime.\nIt reflects the set of data which has to be searched through to compute for example a count(*) of the data. \n\nThe labels correspond to the following size categories (expected number of rows at production customers):\n- S: less than 1000\n- M: less than 100.000\n- L: less than 10.000.000\n- XL: less than 100.000.000  \n- XXL: more than 100.000.000",
+      "description": "The size category enables the consumer to judge the possible result data set size.\nIt is a pure estimation at design time while modeling the entity what the data set size would be at runtime.\nIt reflects the set of data which has to be searched through to compute for example a count(*) of the data.\n\nThe labels correspond to the following size categories (expected number of rows at production customers):\n- S: less than 1000\n- M: less than 100.000\n- L: less than 10.000.000\n- XL: less than 100.000.000\n- XXL: more than 100.000.000",
       "properties": {
         "#": {
           "type": "string",

--- a/src/generated/spec-v1/types/csn-interop-effective.ts
+++ b/src/generated/spec-v1/types/csn-interop-effective.ts
@@ -101,6 +101,16 @@ export type EntityRelationship = ReferenceTarget[];
  */
 export type ObjectModel = unknown[];
 /**
+ * State the owner of the CSN model part, where it differs from the main ownership.
+ * This can happen with extensions, which can be created by customers, partners or by industry extensions.
+ *
+ * The value MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1#namespaces).
+ * If the annotation is not present, the owner is identical to the owner of the overall CSN model.
+ *
+ * For extensions created by the customer / owner of the system instance, use the reserved `customer` namespace.
+ */
+export type ObjectModelOwner = string;
+/**
  * The property contains element(s) containing a text for the annotated (id)element
  */
 export type ObjectModelText = unknown[];
@@ -676,6 +686,7 @@ export interface EntityDefinition {
   "@EntityRelationship.referencesWithConstantIds"?: EntityRelationship5;
   "@ObjectModel.compositionRoot"?: ObjectModelCompositionRoot;
   "@ObjectModel.representativeKey"?: ElementReference;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   "@ObjectModel.tenantWideUniqueName"?: ObjectModelTenantWideUniqueName;
@@ -759,6 +770,7 @@ export interface BooleanType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -972,6 +984,7 @@ export interface StringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1116,6 +1129,7 @@ export interface LargeStringType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1213,6 +1227,7 @@ export interface IntegerType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1342,6 +1357,7 @@ export interface Integer64Type {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1446,6 +1462,7 @@ export interface DecimalType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1545,6 +1562,7 @@ export interface DoubleType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1643,6 +1661,7 @@ export interface DateType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1740,6 +1759,7 @@ export interface TimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1837,6 +1857,7 @@ export interface DateTimeType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -1934,6 +1955,7 @@ export interface TimestampType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2030,6 +2052,7 @@ export interface UUIDType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2148,6 +2171,7 @@ export interface AssociationType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2316,6 +2340,7 @@ export interface CompositionType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2449,6 +2474,7 @@ export interface CustomType {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2762,6 +2788,7 @@ export interface ServiceDefinition {
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.quickInfo"?: EndUserTextQuickInfo;
   "@ObjectModel.representativeKey"?: ElementReference;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.modelingPattern"?: ObjectModel1;
   "@ObjectModel.supportedCapabilities"?: ObjectModel2;
   /**
@@ -2819,6 +2846,7 @@ export interface BooleanTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -2920,6 +2948,7 @@ export interface StringTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3021,6 +3050,7 @@ export interface LargeStringTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3117,6 +3147,7 @@ export interface IntegerTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3214,6 +3245,7 @@ export interface Integer64TypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3322,6 +3354,7 @@ export interface DecimalTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3419,6 +3452,7 @@ export interface DoubleTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3516,6 +3550,7 @@ export interface DateTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3612,6 +3647,7 @@ export interface TimeTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3708,6 +3744,7 @@ export interface DateTimeTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3804,6 +3841,7 @@ export interface TimestampTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -3899,6 +3937,7 @@ export interface UUIDTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -4018,6 +4057,7 @@ export interface AssociationTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;
@@ -4137,6 +4177,7 @@ export interface CompositionTypeDefinition {
   "@EntityRelationship.propertyType"?: EntityRelationshipPropertyType;
   "@EntityRelationship.reference"?: EntityRelationship;
   "@ObjectModel.semanticKey"?: ObjectModel;
+  "@ObjectModel.owner"?: ObjectModelOwner;
   "@ObjectModel.foreignKey.association"?: ElementReference;
   "@ObjectModel.text.element"?: ObjectModelText;
   "@ObjectModel.text.association"?: ElementReference;


### PR DESCRIPTION
### Added

- Added `@ObjectModel.owner` annotation to state ownership for parts of the CSN model where it differs from the main ownership.


Relates #64 