### PR TITLE
Propose @ORD vocabulary for backlinks to ORD metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ### Added
 
 - Added missing property `$id` to annotation extension schemas
+- ADDED: Added `@ORD` annotation vocabulary
+  - Added `@ORD.ordIds` to correlate CSN Service and Entity to its ORD API Resource, Event Resource and Entity Type equivalents.
 
 ## [1.0.3]
 

--- a/spec-toolkit.config.json
+++ b/spec-toolkit.config.json
@@ -111,6 +111,19 @@
     },
     {
       "type": "specExtension",
+      "id": "ord",
+      "sourceFilePath": "./spec/v1/annotations/ord.yaml",
+      "sourceIntroFilePath": "./spec/v1/annotations/ord.md",
+      "targetDocumentId": "csn-interop-effective",
+      "targetLink": "../spec-v1/csn-interop-effective",
+      "mdFrontmatter": {
+        "title": "@ORD",
+        "sidebar_position": 9,
+        "description": "@ORD for Open Resource Discovery related annotations."
+      }
+    },
+    {
+      "type": "specExtension",
       "id": "personal-data",
       "sourceFilePath": "./spec/v1/annotations/personal-data.yaml",
       "sourceIntroFilePath": "./spec/v1/annotations/personal-data.md",
@@ -118,7 +131,7 @@
       "targetLink": "../spec-v1/csn-interop-effective",
       "mdFrontmatter": {
         "title": "@PersonalData",
-        "sidebar_position": 9,
+        "sidebar_position": 10,
         "description": "@PersonalData to annotate DPP relevant information."
       }
     },
@@ -131,7 +144,7 @@
       "targetLink": "../spec-v1/csn-interop-effective",
       "mdFrontmatter": {
         "title": "@Semantics",
-        "sidebar_position": 10,
+        "sidebar_position": 11,
         "description": "@Semantics annotations."
       }
     }

--- a/spec/v1/annotations/ord.md
+++ b/spec/v1/annotations/ord.md
@@ -1,0 +1,14 @@
+> <span className="feature-status-beta">BETA</span> This annotation is beta and should be reviewed for completion and correctness.
+
+## Introduction
+
+[Open Resource Discovery](https://sap.github.io/open-resource-discovery/) (ORD) is a complementary standard to CSN Interop.
+It's purpose is to provide a decentralized protocol for metadata publishing and discovery of applications and services.
+From ORD perspective, CSN Interop is a possible resource definition format that can be attached to API and Event resources.
+
+On the ORD level, more high-level context can be found and expressed, that is shared across different protocols and standards.
+Also it covers (global) taxonomy and relationships between high-level concepts.
+
+With this annotations it's possible to connect the CSN Interop concepts back to the high-level ORD concepts.
+
+> 🔗 Visit the public [Open Resource Discovery](https://sap.github.io/open-resource-discovery/) page.

--- a/spec/v1/examples/airline.json
+++ b/spec/v1/examples/airline.json
@@ -15,7 +15,8 @@
   "definitions": {
     "AirlineService": {
       "kind": "service",
-      "doc": "This is describing the service that exposes the CDS entities through an API."
+      "doc": "This is describing the service that exposes the CDS entities through an API.",
+      "@ORD.ordIds": ["sap.foo:apiResource:AirlineDeltaShare:v1"]
     },
     "AirlineService.Airline": {
       "kind": "entity",
@@ -24,6 +25,7 @@
       "@ObjectModel.modelingPattern": {
         "#": "ANALYTICAL_DIMENSION"
       },
+      "@ORD.ordIds": ["sap.foo:entityType:Airline:v1"],
       "elements": {
         "AirlineID": {
           "@EndUserText.label": "Airline",

--- a/spec/v1/ord.yaml
+++ b/spec/v1/ord.yaml
@@ -1,0 +1,20 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: "ORD"
+x-extension:
+  targetDocument: "./spec/v1/CSN-Interop-Effective.schema.yaml"
+  targetLink: "../spec-v1/csn-interop-effective"
+
+definitions:
+  "@ORD.ordIds":
+    type: array
+    items:
+      type: string
+      pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(apiResource|eventResource|entityType):([a-zA-Z0-9._\-]+):(v0|v[1-9][0-9]*|)$
+    description: |-
+      The [ORD ID](https://sap.github.io/open-resource-discovery/spec-v1#ord-id) of the CSN definition.
+      It can be an array, because a singe CDS [Service](../spec-v1/csn-interop-effective#i18n) can be exposed via multiple concrete API or Event protocols.
+    examples:
+      - ["sap.s4:apiResource:API_BILL_OF_MATERIAL_SRV:v1"]
+    x-extension-targets:
+      - "Entity"
+      - "Service"


### PR DESCRIPTION
Proposal is to be able to create a connection (potentially back) to the [ORD ](https://open-resource-discovery.github.io/specification/) layer, where the API, Event Resources and Entitles are also described, with shared high-level properties (like lifecycle, taxonomy) and relationships across concepts.

If we want to import a CSN Interop document to add it as an "Integration Dependency", we also need to know its ORD ID. If the document already contains it, that makes the import of CSN much easier.

### Open Questions

- [ ] Should we allow for `meta.document` annotations to ORD IDs? Depending on the granularity of the content in the CSN Document, it could be possible to link the entire document to ORD API Resources (if only one service is described) or ORD Data Product (if the scope of the document is to describe the Data Product data model).

### Example

```js
{ // ..
  "definitions": {
    "AirlineService": {
      "kind": "service",
      "doc": "This is describing the service that exposes the CDS entities through an API. Which protocol is used could be provided through `@protocol` today. For CSN Interop, we consider introducing an aligned, more flexible `@Service.api` annotation",
      "@ORD.ordIds": ["sap.foo:apiResource:AirlineDeltaShare:v1"],
      ]
    },
    "AirlineService.Airline": {
      "kind": "entity",
      "doc": "Human readable description of the entity, in **markdown**.",
      "@ORD.ordIds": ["sap.foo:entityType:Airline:v1"],
```