### PR TITLE
Precision and scale are RECOMMENDED to be added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 - Added missing property `$id` to annotation extension schemas
 - Added clarification that `key: true` also implies `notNull: true`
+- Added clarification that `precision` and `scale` are RECOMMENDED to be added and MUST be added if own default assumptions diverge from the specified default.
 
 ## [1.0.3]
 

--- a/spec/v1/CSN-Interop-Effective.schema.yaml
+++ b/spec/v1/CSN-Interop-Effective.schema.yaml
@@ -851,6 +851,8 @@ definitions:
           Total number of digits in a number.
           This includes both the digits before and after the decimal point.
 
+          SHOULD be explicitly provided and MUST be provided if own default assumptions diverge from specified default of `34`.
+
           The semantics of the choices follows the [OData v4 Precision](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Precision) specification.
         default: 34
       scale: &scale
@@ -859,11 +861,16 @@ definitions:
           - $ref: "#/definitions/DecimalScaleType"
         description: |-
           Describes the number of digits to the right of the decimal point in a number.
+
+          SHOULD be explicitly provided and MUST be provided if own default assumptions diverge from specified default of `floating`.
         default: "floating"
     patternProperties: *patternPropertiesAnnotationsAndPrivate
     required:
       - type
     additionalProperties: false
+    x-recommended:
+      - precision
+      - scale
     x-extension-points:
       - Type
       - DecimalType


### PR DESCRIPTION
- Added clarification that `precision` and `scale` are RECOMMENDED to be added and MUST be added if own default assumptions diverge from the specified default.
