### PR TITLE
Forbit v0 and v1 in entityType and propertyType IDs

### DIFF
--- a/spec/v1/annotations/entity-relationship.outro.md
+++ b/spec/v1/annotations/entity-relationship.outro.md
@@ -47,7 +47,7 @@ The ID scheme for an Entity Type ID is as following:
 <entityTypeId> := <namespace>:<entityTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$`
+- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$`
 
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
@@ -85,7 +85,7 @@ A [Property Type ID](#property-type-id) follows the same format and consideratio
 <PropertyTypeId> := <namespace>:<propertyTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$`
+- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$`
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
 - The `<propertyTypeLocalId>` part MUST match the regexp `^[a-zA-Z0-9._\-]+$` and follows the ORD ID `<resourceName>` constraints:

--- a/spec/v1/annotations/entity-relationship.outro.md
+++ b/spec/v1/annotations/entity-relationship.outro.md
@@ -47,7 +47,7 @@ The ID scheme for an Entity Type ID is as following:
 <entityTypeId> := <namespace>:<entityTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$`
+- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$`
 
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
@@ -85,7 +85,7 @@ A [Property Type ID](#property-type-id) follows the same format and consideratio
 <PropertyTypeId> := <namespace>:<propertyTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$`
+- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$`
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
 - The `<propertyTypeLocalId>` part MUST match the regexp `^[a-zA-Z0-9._\-]+$` and follows the ORD ID `<resourceName>` constraints:

--- a/spec/v1/annotations/entity-relationship.outro.md
+++ b/spec/v1/annotations/entity-relationship.outro.md
@@ -47,7 +47,7 @@ The ID scheme for an Entity Type ID is as following:
 <entityTypeId> := <namespace>:<entityTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$`
+- Complete `<entityTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$`
 
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
@@ -56,7 +56,7 @@ The ID scheme for an Entity Type ID is as following:
   - MUST be unique within the `<namespace>`.
   - SHOULD be a (somewhat) human readable and SEO/URL friendly string (avoid UUIDs).
 
-- The `<majorVersion>` is optional. If provided MUST be a positive integer (prefixed with `v`)
+- The `<majorVersion>` MUST only be provided if the major version is above v1. For v1 it MUST be omitted.
 
 In many cases Entity Types are not versioned. To ease handling and avoiding ambiguity, we forbid adding `v1` and therefore made `v1` the default.
 If for the case of having a `v2` or higher of an Entity Type, the version must be added.
@@ -85,7 +85,7 @@ A [Property Type ID](#property-type-id) follows the same format and consideratio
 <PropertyTypeId> := <namespace>:<propertyTypeLocalId>[:v<majorVersion>]
 ```
 
-- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$`
+- Complete `<PropertyTypeId>` MUST match the regexp `^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$`
 - The `<namespace>` part MUST be a valid [ORD namespace](https://open-resource-discovery.github.io/specification/spec-v1/#namespaces).
 
 - The `<propertyTypeLocalId>` part MUST match the regexp `^[a-zA-Z0-9._\-]+$` and follows the ORD ID `<resourceName>` constraints:
@@ -93,7 +93,7 @@ A [Property Type ID](#property-type-id) follows the same format and consideratio
   - MUST be unique within the `<namespace>`.
   - SHOULD be a (somewhat) human readable and SEO/URL friendly string (avoid UUIDs).
 
-- The `<majorVersion>` is optional. If provided MUST be a positive integer (prefixed with `v`)
+- The `<majorVersion>` MUST only be provided if the major version is above v1. For v1 it MUST be omitted.
 
 The same Property Type MUST NOT be defined more than once in the same Entity Type.
 However, the same Property Type MAY be part of multiple references within the same Entity Type.

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -11,7 +11,7 @@ definitions:
 
       There could be several data objects that are assigned to the same Entity Type.
       One data object can only have one Entity Type assigned, which corresponds to the applications own Entity Type definition.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
     x-extension-targets:
@@ -22,7 +22,7 @@ definitions:
     description: |-
       Defines the logical [Property Type](#property-type) of a property.
       The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
     examples:
       - "sap.vdm.gfn:BillOfMaterialUUID"
     x-extension-targets:
@@ -305,7 +305,7 @@ definitions:
   "@EntityRelationship.PropertyTypeID":
     title: Property Type ID
     type: string
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
     description: |-
       ID of the [Property Type](#property-type). The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
     examples:
@@ -316,7 +316,7 @@ definitions:
     type: string
     description: |-
       ID of the [Entity Type](#entity-type).
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
 

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -11,7 +11,7 @@ definitions:
 
       There could be several data objects that are assigned to the same Entity Type.
       One data object can only have one Entity Type assigned, which corresponds to the applications own Entity Type definition.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
     x-extension-targets:
@@ -22,7 +22,7 @@ definitions:
     description: |-
       Defines the logical [Property Type](#property-type) of a property.
       The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$
     examples:
       - "sap.vdm.gfn:BillOfMaterialUUID"
     x-extension-targets:
@@ -305,7 +305,7 @@ definitions:
   "@EntityRelationship.PropertyTypeID":
     title: Property Type ID
     type: string
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$
     description: |-
       ID of the [Property Type](#property-type). The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
     examples:
@@ -316,7 +316,7 @@ definitions:
     type: string
     description: |-
       ID of the [Entity Type](#entity-type).
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[2-9][0-9]*|)?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:v[1-9][0-9]*)?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
 

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -11,7 +11,7 @@ definitions:
 
       There could be several data objects that are assigned to the same Entity Type.
       One data object can only have one Entity Type assigned, which corresponds to the applications own Entity Type definition.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
     x-extension-targets:
@@ -22,7 +22,7 @@ definitions:
     description: |-
       Defines the logical [Property Type](#property-type) of a property.
       The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
     examples:
       - "sap.vdm.gfn:BillOfMaterialUUID"
     x-extension-targets:
@@ -305,7 +305,7 @@ definitions:
   "@EntityRelationship.PropertyTypeID":
     title: Property Type ID
     type: string
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
     description: |-
       ID of the [Property Type](#property-type). The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.
     examples:
@@ -316,7 +316,7 @@ definitions:
     type: string
     description: |-
       ID of the [Entity Type](#entity-type).
-    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v0|v[1-9][0-9]*|))?$
+    pattern: ^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\-]+)(:(v[2-9][0-9]*|))?$
     examples:
       - "sap.vdm.sont:BillOfMaterial"
 

--- a/src/generated/spec-v1/schemas/csn-interop-effective.schema.json
+++ b/src/generated/spec-v1/schemas/csn-interop-effective.schema.json
@@ -8141,7 +8141,7 @@
     "@EntityRelationship.entityType": {
       "type": "string",
       "description": "Defines which [Entity Type](#entity-type) the current data object represents.\n\nThere could be several data objects that are assigned to the same Entity Type.\nOne data object can only have one Entity Type assigned, which corresponds to the applications own Entity Type definition.",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.sont:BillOfMaterial"
       ],
@@ -8152,7 +8152,7 @@
     "@EntityRelationship.propertyType": {
       "type": "string",
       "description": "Defines the logical [Property Type](#property-type) of a property.\nThe reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.gfn:BillOfMaterialUUID"
       ],
@@ -8473,7 +8473,7 @@
     "@EntityRelationship.PropertyTypeID": {
       "title": "Property Type ID",
       "type": "string",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "description": "ID of the [Property Type](#property-type). The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.",
       "examples": [
         "sap.vdm.gfn:BillOfMaterialUUID"
@@ -8483,7 +8483,7 @@
       "title": "Entity Type ID",
       "type": "string",
       "description": "ID of the [Entity Type](#entity-type).",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.sont:BillOfMaterial"
       ]

--- a/src/generated/spec-v1/schemas/entity-relationship.schema.json
+++ b/src/generated/spec-v1/schemas/entity-relationship.schema.json
@@ -8,7 +8,7 @@
     "@EntityRelationship.entityType": {
       "type": "string",
       "description": "Defines which [Entity Type](#entity-type) the current data object represents.\n\nThere could be several data objects that are assigned to the same Entity Type.\nOne data object can only have one Entity Type assigned, which corresponds to the applications own Entity Type definition.",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.sont:BillOfMaterial"
       ],
@@ -20,7 +20,7 @@
     "@EntityRelationship.propertyType": {
       "type": "string",
       "description": "Defines the logical [Property Type](#property-type) of a property.\nThe reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.gfn:BillOfMaterialUUID"
       ],
@@ -351,7 +351,7 @@
     "@EntityRelationship.PropertyTypeID": {
       "title": "Property Type ID",
       "type": "string",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "description": "ID of the [Property Type](#property-type). The reason is to have an ID to relate to the property, especially to state that it can be used as an ID or is part of a composite ID.",
       "examples": [
         "sap.vdm.gfn:BillOfMaterialUUID"
@@ -361,7 +361,7 @@
       "title": "Entity Type ID",
       "type": "string",
       "description": "ID of the [Entity Type](#entity-type).",
-      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:(v0|v[1-9][0-9]*|))?$",
+      "pattern": "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+)(:v[2-9][0-9]*|)?$",
       "examples": [
         "sap.vdm.sont:BillOfMaterial"
       ]


### PR DESCRIPTION
Follow up on #88 

@swennemers  your feedback was that we should explicitly forbid `v1` to be explicitly stated. I think we should then also forbid `v0`. Then we don't get accidental inconsistencies where things should match up without having to parse the value.