### PR TITLE
fix(typescript-types): package is missing schema typescript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [1.0.5]
+
+### Fixed
+
+- typescript type `SpecJsonSchemaRoot` is missing in the packed NpmJS artefact
+
 ## [1.0.4]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sap/csn-interop-specification",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sap/csn-interop-specification",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
         "@docusaurus/core": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "@sap/csn-interop-specification",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "CSN Interop Specification.",
   "author": "SAP SE",
   "license": "Apache-2.0",
@@ -20,7 +20,8 @@
     "README.md",
     "dist/src/index.js",
     "dist/src/index.d.ts",
-    "dist/src/generated/spec-v1"
+    "dist/src/generated/spec-v1",
+    "dist/spec-toolkit/*"
   ],
   "scripts": {
     "clean": "tsx src/clean.ts",


### PR DESCRIPTION
Fixed: packed npmjs artefact was missing typescript types.