### PR TITLE
fix(docu): regex special characters escaping in markdown result

### DIFF
--- a/spec-toolkit/src/util/markdownTextHelper.ts
+++ b/spec-toolkit/src/util/markdownTextHelper.ts
@@ -34,7 +34,19 @@ export function escapeTextInTable(text: string | string[] | unknown, jsonStringi
 }
 
 export function escapeRegexpInTable(text: string): string {
-  const escapedRegexp = text.split("|").join(`\\|`).split("{").join(`\\{`).split("}").join(`\\}`);
+  const escapedRegexp = text
+    .split("\\")
+    .join(`\\\\`)
+    .split("|")
+    .join(`\\|`)
+    .split("{")
+    .join(`\\{`)
+    .split("}")
+    .join(`\\}`)
+    .split(":")
+    .join(`\\:`)
+    .split("*")
+    .join(`\\*`);
   return `<code className="regex">${escapedRegexp}</code>`;
 }
 


### PR DESCRIPTION
Some characters used in regexp needed escaping for being properly rendered in the markdown documentation.

E.g.

Before the fix:
![image](https://github.com/user-attachments/assets/00289c4a-8331-49f5-bc2c-0b216f23b758)


After:
![image](https://github.com/user-attachments/assets/1e6a6427-50a0-42c1-8dfe-2973406b9adb)
