### PR TITLE
Specify uniqueness constraint for reference name and update code examples

### DIFF
--- a/spec/v1/annotations/entity-relationship.outro.md
+++ b/spec/v1/annotations/entity-relationship.outro.md
@@ -115,7 +115,7 @@ The following example shows a single ID in '@EntityRelationship.entityIds' that 
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:BillOfMaterial'
 @EntityRelationship.entityIds : [{
-  name: 'optional name for ID'
+  name: 'BillOfMaterialObjectId'
   propertyTypes: ['sap.vdm.gfn:BillOfMaterialObjectID']
 }]
 entity BillOfMaterial {
@@ -133,7 +133,7 @@ In the following example, the annotation is used to indicate which Property Type
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:BusinessPartner'
 @EntityRelationship.entityIds : [{
-  name: 'Semantic ID'
+  name: 'SemanticId'
   propertyTypes: ['sap.vdm.gfn:BusinessPartnerNumber', 'sap.vdm.gfn:BusinessPartnerType']
 },{
   name: 'UUID'
@@ -209,7 +209,7 @@ A property can be potentially part of several composite references.
 @EntityRelationship.entityType : 'sap.vdm.sont:PurchaseOrder'
 @EntityRelationship.compositeReferences : [{
   //one composite reference
-  name: 'Main Supplier',
+  name: 'MainSupplier',
   referencedEntityType: 'sap.vdm.sont:BusinessPartner'
   referencedPropertyTypes: [{
     referencedPropertyType: 'sap.vdm.gfn:BusinessPartnerNumber',
@@ -221,7 +221,7 @@ A property can be potentially part of several composite references.
 },{
   // This demonstrates why the composite reference is necessary
   // and is defined with the semantics from the referencing side.
-  name: 'Alternative Supplier',
+  name: 'AlternativeSupplier',
   referencedEntityType: 'sap.vdm.sont:BusinessPartner'
   referencedPropertyTypes: [{
     referencedPropertyType: 'sap.vdm.gfn:BusinessPartnerNumber',
@@ -272,10 +272,10 @@ Those three together can be used to create a unique reference that also states t
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:CostCenter'
 @EntityRelationship.entityIds : [{
-  name: 'ID for Point in Time'
+  name: 'PointInTimeId'
   propertyTypes: ["sap.vdm.gfn:ControllingArea", "sap.vdm.gfn:CostCenter", "sap.vdm.gfn:KeyDate"]
 },{
-  name: 'Time-independent ID (not unique)'
+  name: 'TimeIndependentId'
   propertyTypes: ["sap.vdm.gfn:ControllingArea", "sap.vdm.gfn:CostCenter"]
 }]
 entity CostCenter {
@@ -297,7 +297,7 @@ Example how this is used in a time dependent reference from `SalesOrder`:
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:SalesOrder'
 @EntityRelationship.compositeReferences : [{
-  name: 'Time Dependent Reference to CostCenter',
+  name: 'TimeDependentCostCenterReference',
   referencedEntityType: 'sap.vdm.sont:CostCenter'
   referencedPropertyTypes: [{
     referencedPropertyType: 'sap.vdm.gfn:ControllingArea',
@@ -354,7 +354,7 @@ A temporal ID can be referenced via `@EntityRelationship.temporalReferences`:
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:SalesOrder'
 @EntityRelationship.temporalReferences : [{
-  name: 'Temporal Reference to CostCenter',
+  name: 'TemporalCostCenterReference',
   referencedEntityType: 'sap.vdm.sont:CostCenter'
   referencedPropertyTypes: [{ // reference-specific assignment to property-types, could include constants
     referencedPropertyType: 'sap.vdm.gfn:ControllingArea',
@@ -390,7 +390,7 @@ As a consequence, there is consumer input needed to resolve the reference.
 ```javascript
 @EntityRelationship.entityType : 'sap.vdm.sont:SalesOrder'
 @EntityRelationship.temporalReferences : [{
-  name: 'Reference to Current CostCenter State',
+  name: 'CurrentCostCenter',
   referencedEntityType: 'sap.vdm.sont:CostCenter'
   referencedPropertyTypes: [{
     referencedPropertyType: 'sap.vdm.gfn:ControllingArea',

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -100,7 +100,8 @@ definitions:
       name:
         type: string
         description: |-
-          Optional name to describe the semantics of the reference.
+          Optional technical name (locally unique ID) of the reference.
+          
           If provided, the name MUST be unique across all reference names defined via
           `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
           `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -101,7 +101,7 @@ definitions:
         type: string
         description: |-
           Optional technical name (locally unique ID) of the reference.
-          
+
           If provided, the name MUST be unique across all reference names defined via
           `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
           `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
@@ -148,7 +148,7 @@ definitions:
         type: string
         description: |-
           Optional technical name (locally unique ID) of the reference.
-          
+
           If provided, the name MUST be unique across all reference names defined via
           `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
           `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -101,6 +101,11 @@ definitions:
         type: string
         description: |-
           Optional name to describe the semantics of the reference.
+          If provided, the name MUST be unique across all reference names defined via
+          `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+          `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+          on the same CSN entity, and MUST NOT match the name of any element
+          (property, `cds.Association`, or `cds.Composition`) of that entity.
       referencedEntityType:
         $ref: "#/definitions/@EntityRelationship.EntityTypeID"
       referencedPropertyType:
@@ -142,6 +147,11 @@ definitions:
         type: string
         description: |-
           Optional name to describe the semantics of the reference.
+          If provided, the name MUST be unique across all reference names defined via
+          `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+          `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+          on the same CSN entity, and MUST NOT match the name of any element
+          (property, `cds.Association`, or `cds.Composition`) of that entity.
       referencedEntityType:
         $ref: "#/definitions/@EntityRelationship.EntityTypeID"
       referencedPropertyTypes:
@@ -217,6 +227,11 @@ definitions:
         type: string
         description: |-
           Optional name to describe the semantics of the reference.
+          If provided, the name MUST be unique across all reference names defined via
+          `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+          `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+          on the same CSN entity, and MUST NOT match the name of any element
+          (property, `cds.Association`, or `cds.Composition`) of that entity.
       referencedEntityType:
         $ref: "#/definitions/@EntityRelationship.EntityTypeID"
       referencedPropertyTypes:
@@ -249,6 +264,11 @@ definitions:
         type: string
         description: |-
           Optional name to describe the semantics of the reference.
+          If provided, the name MUST be unique across all reference names defined via
+          `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+          `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+          on the same CSN entity, and MUST NOT match the name of any element
+          (property, `cds.Association`, or `cds.Composition`) of that entity.
       description:
         type: string
         description: |-
@@ -381,10 +401,10 @@ examples:
               "@EntityRelationship.entityIds":
                 [
                   {
-                    "name": "Semantic ID (composite ID)",
+                    "name": "SemanticId",
                     "propertyTypes": ["sap.vdm.gfn:BusinessPartnerNumber", "sap.vdm.gfn:BusinessPartnerType"],
                   },
-                  { "name": "UUID (single property ID)", "propertyTypes": ["sap.vdm.gfn:BusinessPartnerUUID"] },
+                  { "name": "UUID", "propertyTypes": ["sap.vdm.gfn:BusinessPartnerUUID"] },
                 ],
               "elements":
                 {
@@ -416,7 +436,7 @@ examples:
               "@EntityRelationship.compositeReferences":
                 [
                   {
-                    "name": "Main Supplier",
+                    "name": "MainSupplier",
                     "referencedEntityType": "sap.vdm.sont:BusinessPartner",
                     "referencedPropertyTypes":
                       [

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -147,7 +147,8 @@ definitions:
       name:
         type: string
         description: |-
-          Optional name to describe the semantics of the reference.
+          Optional technical name (locally unique ID) of the reference.
+          
           If provided, the name MUST be unique across all reference names defined via
           `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
           `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`

--- a/src/generated/spec/v1/types/csn-interop-effective.ts
+++ b/src/generated/spec/v1/types/csn-interop-effective.ts
@@ -974,7 +974,13 @@ export interface ElementReferenceObject {
  */
 export interface ReferenceTarget {
   /**
-   * Optional name to describe the semantics of the reference.
+   * Optional technical name (locally unique ID) of the reference.
+   *
+   * If provided, the name MUST be unique across all reference names defined via
+   * `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+   * `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+   * on the same CSN entity, and MUST NOT match the name of any element
+   * (property, `cds.Association`, or `cds.Composition`) of that entity.
    */
   name?: string;
   referencedEntityType: EntityTypeID;
@@ -3136,7 +3142,13 @@ export interface EntityID {
  */
 export interface CompositeReference {
   /**
-   * Optional name to describe the semantics of the reference.
+   * Optional technical name (locally unique ID) of the reference.
+   *
+   * If provided, the name MUST be unique across all reference names defined via
+   * `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+   * `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+   * on the same CSN entity, and MUST NOT match the name of any element
+   * (property, `cds.Association`, or `cds.Composition`) of that entity.
    */
   name?: string;
   referencedEntityType: EntityTypeID;
@@ -3200,6 +3212,11 @@ export interface TemporalType {
 export interface TemporalReference {
   /**
    * Optional name to describe the semantics of the reference.
+   * If provided, the name MUST be unique across all reference names defined via
+   * `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+   * `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+   * on the same CSN entity, and MUST NOT match the name of any element
+   * (property, `cds.Association`, or `cds.Composition`) of that entity.
    */
   name?: string;
   referencedEntityType: EntityTypeID;
@@ -3226,6 +3243,11 @@ export interface Category {
 export interface ReferenceWithConstantID {
   /**
    * Optional name to describe the semantics of the reference.
+   * If provided, the name MUST be unique across all reference names defined via
+   * `@EntityRelationship.reference`, `@EntityRelationship.compositeReferences`,
+   * `@EntityRelationship.temporalReferences`, and `@EntityRelationship.referencesWithConstantIds`
+   * on the same CSN entity, and MUST NOT match the name of any element
+   * (property, `cds.Association`, or `cds.Composition`) of that entity.
    */
   name?: string;
   /**


### PR DESCRIPTION
The optional `name` field on reference objects (ReferenceTarget, CompositeReference, TemporalReference, ReferenceTargetWithConstantId) must be unique across all reference names on the same CSN entity and must not match any element name (property, cds.Association, cds.Composition).

Updated entity-relationship.yaml to document this constraint in the `name` description of all four affected schema types.

Updated code examples to use PascalCase names without spaces, so they serve as good role models for the constraint.