### PR TITLE
Require at least one entry in mandatory EntityRelationship arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Fixed
+
+- Added JSON Schema `minItems: 1` constraint to the mandatory arrays in the `@EntityRelationship` vocabulary, so an empty array no longer passes validation for a required list. Affects `@EntityRelationship.EntityId.propertyTypes`, `@EntityRelationship.CompositeReference.referencedPropertyTypes`, `@EntityRelationship.TemporalId.propertyTypes`, `@EntityRelationship.TemporalReference.referencedPropertyTypes`, and `@EntityRelationship.ReferenceTargetWithConstantId.referencedPropertyTypes`
+
 ## [1.2.5]
 
 ### Added

--- a/spec/v1/annotations/entity-relationship.yaml
+++ b/spec/v1/annotations/entity-relationship.yaml
@@ -133,6 +133,7 @@ definitions:
         type: array
         description: |-
           List of [Property Type](#property-type) IDs.
+        minItems: 1
         items:
           $ref: "#/definitions/@EntityRelationship.PropertyTypeID"
     required:
@@ -160,6 +161,7 @@ definitions:
         type: array
         description: |-
           List of properties, the composite ID consists of.
+        minItems: 1
         items:
           $ref: "#/definitions/@EntityRelationship.ReferenceTargetPropertyType"
     required:
@@ -198,6 +200,7 @@ definitions:
         type: array
         description: |-
           List of [Property Type](#property-type) IDs that are non-temporal.
+        minItems: 1
         items:
           $ref: "#/definitions/@EntityRelationship.PropertyTypeID"
       temporalIntervalType:
@@ -240,6 +243,7 @@ definitions:
         type: array
         description: |-
           List of non-temporal properties the composite temporal ID consists of.
+        minItems: 1
         items:
           $ref: "#/definitions/@EntityRelationship.ReferenceTargetPropertyType"
       category:
@@ -281,6 +285,7 @@ definitions:
         type: array
         description: |-
           List of properties, the composite ID consists of.
+        minItems: 1
         items:
           $ref: "#/definitions/@EntityRelationship.ReferenceTargetPropertyTypeWithConstantId"
     required:

--- a/src/generated/spec/v1/types/csn-interop-effective.ts
+++ b/src/generated/spec/v1/types/csn-interop-effective.ts
@@ -84,6 +84,10 @@ export type APIElementDecommissioningPlannedForYearMonth = string;
  */
 export type Consumption = ConsumptionValueHelpDefinition[];
 /**
+ * The annotated element shall be ignored by consumers.
+ */
+export type ConsumptionHidden = boolean;
+/**
  * Specifies that the data of the element or entity is unavailable although it is part of the output structure.
  */
 export type DataIntegrationDataUnavailable = boolean;
@@ -302,6 +306,14 @@ export type GreaterEqualsOperator = ">=";
  * The operator `and`
  */
 export type ANDOperator = "and";
+/**
+ * The annotation describes the planned decommissioning date of the annotated entity. Use ISO format for YearMonth: YYYY-MM (e.g. 2024-08)
+ */
+export type APIEntityDecommissioningPlannedForYearMonth = string;
+/**
+ * Defines the name of a released successor entity which replaces an entity with release state #DEPRECATED or #DECOMMISSIONED.
+ */
+export type APIEntitySuccessor = string;
 /**
  * Defines which [Entity Type](#entity-type) the current data object represents.
  *
@@ -721,10 +733,9 @@ export interface EntityDefinition {
     | {
         [k: string]: unknown | undefined;
       };
-  "@API.element"?: API;
-  "@API.element.decommissioningPlannedForYearMonth"?: APIElementDecommissioningPlannedForYearMonth;
-  "@API.element.successor"?: ElementReference;
-  "@API.element.releaseState"?: APIElement;
+  "@API.entity.decommissioningPlannedForYearMonth"?: APIEntityDecommissioningPlannedForYearMonth;
+  "@API.entity.successor"?: APIEntitySuccessor;
+  "@API.entity.releaseState"?: APIEntity;
   "@Consumption.valueHelpDefinition"?: Consumption;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
@@ -823,6 +834,7 @@ export interface BooleanType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1096,6 +1108,7 @@ export interface StringType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1246,6 +1259,7 @@ export interface LargeStringType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1353,6 +1367,7 @@ export interface IntegerType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1489,6 +1504,7 @@ export interface Int16Type {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1594,6 +1610,7 @@ export interface Integer64Type {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1699,6 +1716,7 @@ export interface UInt8Type {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1819,6 +1837,7 @@ export interface DecimalType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -1923,6 +1942,7 @@ export interface DoubleType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2028,6 +2048,7 @@ export interface DateType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2132,6 +2153,7 @@ export interface TimeType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2236,6 +2258,7 @@ export interface DateTimeType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2340,6 +2363,7 @@ export interface TimestampType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2443,6 +2467,7 @@ export interface UUIDType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2552,6 +2577,7 @@ export interface BinaryType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2653,6 +2679,7 @@ export interface LargeBinaryType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -2817,6 +2844,7 @@ export interface AssociationType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3028,6 +3056,7 @@ export interface CompositionType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3173,6 +3202,7 @@ export interface CustomType {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3255,6 +3285,16 @@ export interface DefaultValueCustomType {
     | null;
 }
 /**
+ * The annotation describes the release state of the annotated entity.
+ */
+export interface APIEntity {
+  /**
+   * Provide the value in `{ "#": "<value>" }` enum notation.
+   */
+  "#"?: "DEPRECATED" | "DECOMMISSIONED";
+  [k: string]: unknown | undefined;
+}
+/**
  * Defines an ID that can be used to look up the Entity Type or create a reference to it.
  */
 export interface EntityID {
@@ -3268,8 +3308,10 @@ export interface EntityID {
   description?: string;
   /**
    * List of [Property Type](#property-type) IDs.
+   *
+   * @minItems 1
    */
-  propertyTypes: PropertyTypeID[];
+  propertyTypes: [PropertyTypeID, ...PropertyTypeID[]];
   [k: string]: unknown | undefined;
 }
 /**
@@ -3289,8 +3331,10 @@ export interface CompositeReference {
   referencedEntityType: EntityTypeID;
   /**
    * List of properties, the composite ID consists of.
+   *
+   * @minItems 1
    */
-  referencedPropertyTypes: ReferencedPropertyType[];
+  referencedPropertyTypes: [ReferencedPropertyType, ...ReferencedPropertyType[]];
   [k: string]: unknown | undefined;
 }
 /**
@@ -3315,8 +3359,10 @@ export interface TemporalID {
   description?: string;
   /**
    * List of [Property Type](#property-type) IDs that are non-temporal.
+   *
+   * @minItems 1
    */
-  propertyTypes: PropertyTypeID[];
+  propertyTypes: [PropertyTypeID, ...PropertyTypeID[]];
   temporalIntervalType: TemporalIntervalType;
   temporalType: TemporalType;
   temporalIntervalStartProperty: LocalPropertyName;
@@ -3357,8 +3403,10 @@ export interface TemporalReference {
   referencedEntityType: EntityTypeID;
   /**
    * List of non-temporal properties the composite temporal ID consists of.
+   *
+   * @minItems 1
    */
-  referencedPropertyTypes: ReferencedPropertyType[];
+  referencedPropertyTypes: [ReferencedPropertyType, ...ReferencedPropertyType[]];
   category: Category;
   selectionDateProperty?: LocalPropertyName;
   [k: string]: unknown | undefined;
@@ -3392,8 +3440,10 @@ export interface ReferenceWithConstantID {
   referencedEntityType: EntityTypeID;
   /**
    * List of properties, the composite ID consists of.
+   *
+   * @minItems 1
    */
-  referencedPropertyTypes: ReferencedPropertyTypeWithConstantID[];
+  referencedPropertyTypes: [ReferencedPropertyTypeWithConstantID, ...ReferencedPropertyTypeWithConstantID[]];
   [k: string]: unknown | undefined;
 }
 /**
@@ -3592,6 +3642,7 @@ export interface BooleanTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3699,6 +3750,7 @@ export interface StringTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3806,6 +3858,7 @@ export interface LargeStringTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -3910,6 +3963,7 @@ export interface IntegerTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4012,6 +4066,7 @@ export interface Int16TypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4114,6 +4169,7 @@ export interface Integer64TypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4216,6 +4272,7 @@ export interface UInt8TypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4333,6 +4390,7 @@ export interface DecimalTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4435,6 +4493,7 @@ export interface DoubleTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4537,6 +4596,7 @@ export interface DateTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4638,6 +4698,7 @@ export interface TimeTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4739,6 +4800,7 @@ export interface DateTimeTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4840,6 +4902,7 @@ export interface TimestampTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -4940,6 +5003,7 @@ export interface UUIDTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -5046,6 +5110,7 @@ export interface BinaryTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -5151,6 +5216,7 @@ export interface LargeBinaryTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -5316,6 +5382,7 @@ export interface AssociationTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;
@@ -5478,6 +5545,7 @@ export interface CompositionTypeDefinition {
   "@API.element.successor"?: ElementReference;
   "@API.element.releaseState"?: APIElement;
   "@Consumption.valueHelpDefinition"?: Consumption;
+  "@Consumption.hidden"?: ConsumptionHidden;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.heading"?: EndUserTextHeading;


### PR DESCRIPTION
Add minItems: 1 to the five required array properties in the @EntityRelationship vocabulary so an empty array no longer passes validation for a mandatory list:
- EntityId.propertyTypes
- CompositeReference.referencedPropertyTypes
- TemporalId.propertyTypes
- TemporalReference.referencedPropertyTypes
- ReferenceTargetWithConstantId.referencedPropertyTypes

Regenerate TypeScript types (brings committed output back in sync with the source annotation YAMLs).