### PR TITLE
Add @Consumption.aiHint annotation to consumption vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `@Consumption.aiHint` annotation for AI consumption hints
+  - Provides a free-text hint for AI consumers (e.g., LLMs or AI agents) on how to use or interpret an Entity, Type, or Service — kept separate from human-readable `@EndUserText` descriptions
+  - For JSON-based metadata formats, the corresponding property is `x-sap-ai-hint`
+
 ### Fixed
 
 - Added JSON Schema `minItems: 1` constraint to the mandatory arrays in the `@EntityRelationship` vocabulary, so an empty array no longer passes validation for a required list. Affects `@EntityRelationship.EntityId.propertyTypes`, `@EntityRelationship.CompositeReference.referencedPropertyTypes`, `@EntityRelationship.TemporalId.propertyTypes`, `@EntityRelationship.TemporalReference.referencedPropertyTypes`, and `@EntityRelationship.ReferenceTargetWithConstantId.referencedPropertyTypes`

--- a/spec/v1/annotations/consumption.md
+++ b/spec/v1/annotations/consumption.md
@@ -3,3 +3,62 @@
 ## Introduction
 
 Via those Annotations the specific behavior is defined which is related to the consumption of CDS content via domain-specific frameworks. This metadata makes no assumptions on the concrete consumption technology/infrastructure but is applicable across multiple consumption technologies (Analytics, OData, …).
+
+## Annotations Overview
+
+| Annotation              | Targets               | Description                                                                      |
+| ----------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| `@Consumption.aiHint`   | Entity, Type, Service | Free-text hint for AI consumers on how to use or interpret the annotated element |
+
+## `@Consumption.aiHint`
+
+**Targets:** Entity, Type, Service (and their elements/properties)
+
+`@Consumption.aiHint` is a string annotation that provides guidance for AI consumers (e.g., LLMs or AI agents) on how to use or interpret the annotated element. It is intentionally kept separate from human-readable descriptions (e.g., `@EndUserText`) so that end-user-facing documentation and AI-targeted guidance can evolve independently.
+
+The annotation value is intended for AI consumption only and MUST NOT be displayed to end users. It MUST be filtered when publishing metadata externally (e.g., to the SAP API Business Hub public catalog).
+
+For JSON-based metadata formats, the corresponding property is [`x-sap-ai-hint`](https://github.tools.sap/CPA/sap-json-schema-specification/blob/main/extension-attributes/x-sap-ai-hint.md).
+
+### Usage
+
+```cds
+entity SalesOrder : managed {
+  @Consumption.aiHint: 'Use this entity to retrieve sales order header data. Filter by CustomerID and CreatedAt for typical lookups. For line items, use the SalesOrderItem entity.'
+  key ID : UUID;
+  CustomerID : String(10);
+  @Consumption.aiHint: 'ISO 4217 three-letter currency code (e.g. USD, EUR). Never a symbol.'
+  TransactionCurrency : String(5);
+  @Consumption.aiHint: 'Integer status code: 1=Open, 2=InProcess, 3=Completed, 4=Cancelled. Do not infer status from other fields.'
+  LifecycleStatus : Integer;
+}
+
+service SalesService {
+  @Consumption.aiHint: 'Exposes sales order read and write operations. Use GET operations for lookups and reporting. Creating or modifying orders requires the SalesOrder.Write scope.'
+  entity SalesOrders as projection on SalesOrder;
+}
+```
+
+### Best practices
+
+Unlike human-readable descriptions, `@Consumption.aiHint` can be explicit about data semantics and usage context that would clutter `@EndUserText` annotations. Focus on what an AI agent needs to decide _whether_ and _how_ to use the entity, type, or service.
+
+Some useful things to include, depending on the target:
+
+- **Entity/Type level**
+  - **Business context** — what business concept or domain object this entity represents
+  - **When to use vs. similar entities** — if multiple entities cover overlapping domains, state which is authoritative and under what conditions
+  - **Disambiguation** — when an entity or property name is misleading or overlaps with something similar
+  - **Format and value constraints** — coding standards (ISO, internal enums, picklists), what values are valid, how to interpret coded fields
+  - **Navigation and relationships** — how to traverse to related entities for common lookup patterns
+
+- **Service level**
+  - **Scope and capabilities** — what business activities the service covers and which operations are available
+  - **Authorization** — required scopes or roles needed to read vs. write
+  - **When NOT to use** — if another service is preferred for a specific use case, state this explicitly to help agents route correctly
+
+Structure `@Consumption.aiHint` values using **lightweight, semantically structured Markdown**:
+
+- **Use consistent labels** — e.g., **Format:**, **When NOT to use:** — so AI systems can extract meaning beyond visual formatting.
+- **Keep content atomic** — one idea per bullet or line; avoid long prose paragraphs.
+- **Lightweight Markdown only** — bullets, bold labels, `inline code` for field names and identifiers. Avoid tables and deep nesting.

--- a/spec/v1/annotations/consumption.md
+++ b/spec/v1/annotations/consumption.md
@@ -4,12 +4,6 @@
 
 Via those Annotations the specific behavior is defined which is related to the consumption of CDS content via domain-specific frameworks. This metadata makes no assumptions on the concrete consumption technology/infrastructure but is applicable across multiple consumption technologies (Analytics, OData, …).
 
-## Annotations Overview
-
-| Annotation              | Targets               | Description                                                                      |
-| ----------------------- | --------------------- | -------------------------------------------------------------------------------- |
-| `@Consumption.aiHint`   | Entity, Type, Service | Free-text hint for AI consumers on how to use or interpret the annotated element |
-
 ## `@Consumption.aiHint`
 
 **Targets:** Entity, Type, Service (and their elements/properties)

--- a/spec/v1/annotations/consumption.yaml
+++ b/spec/v1/annotations/consumption.yaml
@@ -119,3 +119,21 @@ definitions:
       - "#"
     examples:
       - { "#": "FILTER_AND_RESULT" }
+
+  "@Consumption.aiHint":
+    type: string
+    description: |-
+      Provides a free-text hint for AI consumers (e.g., LLMs or AI agents) on how to use or interpret the annotated element.
+
+      This allows keeping human-readable descriptions (e.g., `@EndUserText`) separate from
+      guidance targeted specifically at AI consumers.
+
+      The annotation value MUST NOT be displayed to end users and MUST be filtered when
+      publishing metadata externally (e.g., to the SAP API Business Hub public catalog).
+    examples:
+      - "Use this entity to look up current inventory levels by product and warehouse."
+      - "This field contains the ISO 4217 currency code, not a currency symbol."
+    x-extension-targets:
+      - Entity
+      - Type
+      - Service


### PR DESCRIPTION
### Added

- Added `@Consumption.aiHint` annotation for AI consumption hints
  - Provides a free-text hint for AI consumers (e.g., LLMs or AI agents) on how to use or interpret an Entity, Type, or Service — kept separate from human-readable `@EndUserText` descriptions
  - For JSON-based metadata formats, the corresponding property is `x-sap-ai-hint`

### Changes from #169

This supersedes #169. Based on review feedback from @frankejoe:

- `@Consumption.aiHint` is added directly to the existing `consumption.md`/`consumption.yaml` files rather than a separate `@AI` vocabulary
- Annotation name follows CDS camelCase convention (`aiHint` instead of `AIHint`)

Closes #169