### PR TITLE
Add @DataIntegration.dataProduct.customDataProvider.partialKeyDefinition annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+### Added
+
+- Added `@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition` annotation: defines a subset of key fields of the CDS entity used for the DELETE operation during delta replication. Must be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy`.
+
 ### Fixed
 
 - Fixed JSON Schema `minItems: 1` constraint to the mandatory arrays in the `@EntityRelationship` vocabulary, so an empty array no longer passes validation for a required list. Affects `@EntityRelationship.EntityId.propertyTypes`, , `@EntityRelationship.TemporalId.propertyTypes`, `@EntityRelationship.TemporalReference.referencedPropertyTypes`, and `@EntityRelationship.ReferenceTargetWithConstantId.referencedPropertyTypes`. `minItems: 2` constraint to `@EntityRelationship.CompositeReference.referencedPropertyTypes`. This is a correction of the schema to follow the specification, having no items, semantically violates the specification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ### Added
 
-- Added `@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition` annotation: defines a subset of key fields of the CDS entity used for the DELETE operation during delta replication. Must be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy`.
+- Added `@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition` annotation: defines a subset of key fields of the CDS entity used for the DELETE operation during delta replication.
 
 ### Fixed
 

--- a/spec/v1/annotations/dataintegration.yaml
+++ b/spec/v1/annotations/dataintegration.yaml
@@ -18,7 +18,6 @@ definitions:
       Defines subset of key fields of the CDS entity used for DELETE operation during delta replication.
 
       **Consistency Constraints:**
-      - Must be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy` annotation.
       - Fields defined in the annotation must be key fields of the CDS entity.
     items:
       x-ref-to-doc:

--- a/spec/v1/annotations/dataintegration.yaml
+++ b/spec/v1/annotations/dataintegration.yaml
@@ -11,3 +11,21 @@ definitions:
     x-extension-targets:
       - Type
       - Entity
+
+  "@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition":
+    type: array
+    description: |-
+      Defines subset of key fields of the CDS entity used for DELETE operation during delta replication.
+
+      **Consistency Constraints:**
+      - Must be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy` annotation.
+      - Fields defined in the annotation must be key fields of the CDS entity.
+    items:
+      x-ref-to-doc:
+        title: Element Reference
+        ref: "#/definitions/ElementReference"
+    minItems: 1
+    x-extension-targets:
+      - "Entity"
+    examples:
+      - ["AirlineCode", "FlightConnectionNumber", "FlightDate"]

--- a/src/generated/spec/v1/types/csn-interop-effective.ts
+++ b/src/generated/spec/v1/types/csn-interop-effective.ts
@@ -315,6 +315,16 @@ export type APIEntityDecommissioningPlannedForYearMonth = string;
  */
 export type APIEntitySuccessor = string;
 /**
+ * Defines subset of key fields of the CDS entity used for DELETE operation during delta replication.
+ *
+ * **Consistency Constraints:**
+ * - Must be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy` annotation.
+ * - Fields defined in the annotation must be key fields of the CDS entity.
+ *
+ * @minItems 1
+ */
+export type DataIntegrationDataProductCustomDataProvider = [unknown, ...unknown[]];
+/**
  * Defines which [Entity Type](#entity-type) the current data object represents.
  *
  * There could be several data objects that are assigned to the same Entity Type.
@@ -738,6 +748,7 @@ export interface EntityDefinition {
   "@API.entity.releaseState"?: APIEntity;
   "@Consumption.valueHelpDefinition"?: Consumption;
   "@DataIntegration.dataUnavailable"?: DataIntegrationDataUnavailable;
+  "@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition"?: DataIntegrationDataProductCustomDataProvider;
   "@EndUserText.label"?: EndUserTextLabel;
   "@EndUserText.quickInfo"?: EndUserTextQuickInfo;
   "@EntityRelationship.entityType"?: EntityRelationshipEntityType;


### PR DESCRIPTION
Adds the `@DataIntegration.dataProduct.customDataProvider.partialKeyDefinition` annotation: defines a subset of key fields of the CDS entity used for the DELETE operation during delta replication.

The constraint requiring it to be used together with `@DataIntegration.dataProduct.customDataProvider.implementedBy` has been removed.